### PR TITLE
feat: add utm-testing and bun-starter plugins

### DIFF
--- a/plugins/utm-testing/.claude-plugin/plugin.json
+++ b/plugins/utm-testing/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+	"name": "utm-testing",
+	"version": "1.0.0",
+	"description": "UTM macOS VM setup, SSH access, and clone-based testing workflows",
+	"author": {
+		"name": "Nathan Vale"
+	},
+	"skills": ["./skills/utm-testing"]
+}

--- a/plugins/utm-testing/skills/utm-testing/SKILL.md
+++ b/plugins/utm-testing/skills/utm-testing/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: utm-testing
+description: >
+  Guide for setting up UTM macOS VMs, SSH access, and testing anything on a
+  fresh macOS environment. Use when discussing: UTM virtual machines, macOS VM
+  testing, fresh macOS environment, clean-slate testing, VM cloning, SSH into
+  VM, installer testing, dotfiles testing, Homebrew testing on VM, CI-style
+  local testing, or any scenario requiring a disposable macOS environment.
+---
+
+# UTM macOS VM Testing
+
+Expert knowledge for creating, configuring, and using UTM macOS VMs as disposable test environments. Clone-based workflow gives you a fresh macOS every time — no snapshots needed.
+
+## Core Workflow
+
+```
+Create Base VM → Configure SSH → Clone → Test → Delete Clone → Repeat
+```
+
+1. **Create a base VM** once — your golden image (see `references/vm-setup.md`)
+2. **Enable SSH** and bake in essentials before cloning (see `references/ssh-access.md`)
+3. **Clone** the base VM for each test run — instant on APFS (see `references/clone-workflow.md`)
+4. **Test** on the clone — install software, break things, experiment freely
+5. **Delete** the clone when done — right-click → Delete in UTM
+6. **Re-clone** for the next test — fresh environment every time
+
+## Quick-Reference Checklist
+
+Use this when you need to spin up a test quickly:
+
+- [ ] Base VM exists and is **shut down**
+- [ ] SSH is enabled in the base VM (System Settings → General → Sharing → Remote Login)
+- [ ] Clone the base VM (UTM → right-click → Clone)
+- [ ] Start the clone, get its IP: `ipconfig getifaddr en0`
+- [ ] SSH from host: `ssh <user>@<ip>`
+- [ ] Run your test (see `references/testing-patterns.md` for common patterns)
+- [ ] Delete the clone when done
+
+## Reference Docs
+
+| Doc | What It Covers |
+|-----|----------------|
+| `references/vm-setup.md` | Creating the base VM, hardware settings, pre-clone checklist |
+| `references/ssh-access.md` | SSH connection, PATH issues, common gotchas |
+| `references/clone-workflow.md` | Clone-as-snapshot pattern, rules, multiple bases |
+| `references/testing-patterns.md` | Shell scripts, git repos, Homebrew, defaults, CI-style |
+
+## Key Principles
+
+- **Never test on the base VM directly** — always clone first
+- **Bake essentials into the base** before cloning (SSH, Xcode CLT, optionally Homebrew)
+- **Shut down the base before cloning** — APFS CoW corruption risk if both run simultaneously
+- **VM IP changes on reboot** (DHCP) — re-check each time
+- **Non-login SSH** doesn't source `.zshrc` — use `bash -l -c "command"` or full paths

--- a/plugins/utm-testing/skills/utm-testing/references/clone-workflow.md
+++ b/plugins/utm-testing/skills/utm-testing/references/clone-workflow.md
@@ -1,0 +1,109 @@
+# Clone-as-Snapshot Pattern
+
+UTM doesn't support snapshots for macOS VMs (Apple Virtualization uses `.img` not `.qcow2`). Instead, use APFS cloning — it's instant and copy-on-write.
+
+## How It Works
+
+1. **Base VM** — your golden image, never run tests on this directly
+2. **Clone for testing** — UTM → right-click VM → Clone (instant on APFS)
+3. **Test on clone** — install software, break things, experiment freely
+4. **Delete clone when done** — right-click → Delete
+5. **Re-clone for next test** — fresh environment every time
+
+APFS clone is copy-on-write: the clone takes zero extra disk space initially. Only changed blocks consume additional storage.
+
+## Rules
+
+### Never run base and clone simultaneously
+
+APFS copy-on-write can corrupt if both the base `.img` and its clone are written to at the same time. Always:
+
+1. Shut down the base VM
+2. Clone it
+3. Only start the clone
+
+### Shut down base before cloning
+
+Don't clone a running or suspended VM. Always shut down cleanly first:
+
+- Inside VM: Apple menu → Shut Down
+- Or from host SSH: `ssh test@<ip> 'sudo shutdown -h now'`
+
+### Name clones clearly
+
+Use a naming convention so you know what each clone is for:
+
+- `macOS-Tahoe-Test-2025-06-15` — date-based
+- `macOS-Tahoe-Test-dotfiles` — purpose-based
+- `macOS-Tahoe-Test-homebrew-v2` — versioned experiments
+
+### Delete clones when done
+
+Clones are disposable. Don't accumulate them — they eventually diverge from the base and consume real disk space.
+
+## Updating the Base
+
+When you improve the base VM (install Xcode CLT, update macOS, add Homebrew):
+
+1. Start the base VM
+2. Make your changes
+3. Shut it down
+4. Delete all existing clones (they're based on the old image)
+5. Create fresh clones from the updated base
+
+## Multiple Bases
+
+Create purpose-specific base VMs if your testing needs vary significantly:
+
+| Base | Contents | Use Case |
+|------|----------|----------|
+| `macOS-Base-Bare` | SSH only | Test installers from scratch, first-run UX |
+| `macOS-Base-Dev` | SSH + Xcode CLT + Homebrew | Test dev tool setups, Brewfiles |
+| `macOS-Base-Full` | SSH + Xcode CLT + Homebrew + git + node | Test project builds |
+
+## Disk Space
+
+- Base VM: ~20-30GB (macOS + installed tools)
+- Clone: ~0 bytes initially (APFS CoW)
+- Clone after testing: varies by what you installed (typically 1-10GB of divergence)
+- Check space: `du -sh ~/Library/Containers/com.utmapp.UTM/Data/Documents/*.utm`
+
+## Automation Tips
+
+### Quick clone + test cycle from the command line
+
+UTM doesn't have a robust CLI, so cloning is manual (right-click in UTM GUI). But once the clone is running, everything else is scriptable:
+
+```bash
+# Wait for VM to boot and get IP (manual step — check UTM GUI)
+VM_IP="192.168.64.5"
+
+# Run your test
+ssh test@$VM_IP 'bash -l -c "cd ~/repo && ./test.sh"'
+
+# Shut down clone when done
+ssh test@$VM_IP 'sudo shutdown -h now'
+
+# Then delete clone in UTM GUI
+```
+
+### Scripted multi-step tests
+
+```bash
+VM_IP="192.168.64.5"
+
+# Step 1: Copy files
+scp -r ./my-project test@$VM_IP:~/
+
+# Step 2: Run setup
+ssh test@$VM_IP 'bash -l -c "cd ~/my-project && ./setup.sh"'
+
+# Step 3: Verify
+ssh test@$VM_IP 'bash -l -c "cd ~/my-project && ./verify.sh"'
+EXIT_CODE=$?
+
+# Step 4: Collect results
+scp test@$VM_IP:~/my-project/results.log ./
+
+echo "Test completed with exit code: $EXIT_CODE"
+```

--- a/plugins/utm-testing/skills/utm-testing/references/ssh-access.md
+++ b/plugins/utm-testing/skills/utm-testing/references/ssh-access.md
@@ -1,0 +1,152 @@
+# SSH Access & Gotchas
+
+How to connect to your UTM macOS VM over SSH, and the problems you'll hit.
+
+## Finding the VM IP
+
+Inside the VM, run:
+
+```bash
+ipconfig getifaddr en0
+```
+
+This returns the VM's IP on the shared network (typically `192.168.64.x`).
+
+**Note:** The IP can change on reboot (DHCP). Always re-check after restarting the VM.
+
+## Connecting
+
+```bash
+# Interactive session:
+ssh test@192.168.64.5
+
+# Single command (non-login shell — .zshrc is NOT sourced):
+ssh test@192.168.64.5 'whoami'
+
+# Login shell (sources .zshrc — needed for Homebrew, custom PATH, etc.):
+ssh test@192.168.64.5 'bash -l -c "brew --version"'
+```
+
+## Common Gotchas
+
+### `brew` not found over SSH
+
+**Problem:** Running `ssh test@<ip> 'brew install something'` fails with `brew: command not found`.
+
+**Why:** SSH single-command mode runs a non-login shell. `.zshrc` is not sourced, so Homebrew's PATH isn't set.
+
+**Fix — any of these:**
+
+```bash
+# Option 1: Use full path
+ssh test@<ip> '/opt/homebrew/bin/brew install something'
+
+# Option 2: Login shell
+ssh test@<ip> 'bash -l -c "brew install something"'
+
+# Option 3: Inline eval
+ssh test@<ip> 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install something'
+```
+
+### Too many authentication failures
+
+**Problem:** `Received disconnect from <ip>: Too many authentication failures`
+
+**Why:** SSH tries all loaded keys from `ssh-agent` before the right one. If you have many keys, it exhausts the allowed attempts.
+
+**Fix:**
+
+```bash
+ssh -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 test@<ip>
+```
+
+Or add to `~/.ssh/config`:
+
+```
+Host test-vm
+    HostName 192.168.64.5
+    User test
+    IdentitiesOnly yes
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+### Permission denied (publickey, password)
+
+**Problem:** `Permission denied` when connecting.
+
+**Possible causes:**
+- Wrong username — UTM macOS VMs use whatever you set during Setup Assistant
+- Remote Login not enabled — check System Settings → General → Sharing → Remote Login
+- Password auth disabled — check `/etc/ssh/sshd_config` for `PasswordAuthentication yes`
+
+### Xcode dialog pops up over SSH
+
+**Problem:** `xcode-select --install` or similar commands trigger a GUI dialog inside the VM, which you can't interact with over SSH.
+
+**Fix:** Install Xcode CLT in the base VM **before cloning** — do it interactively in the VM GUI. Then every clone has it pre-installed.
+
+### Non-login shell doesn't have your PATH
+
+**Problem:** Commands that work interactively in the VM fail when run via `ssh user@ip "command"`.
+
+**Why:** SSH single-command mode runs a non-login, non-interactive shell. Only `/etc/profile` and `~/.ssh/environment` are sourced (if enabled). Your `.zshrc`, `.zprofile`, `.bashrc` are NOT sourced.
+
+**Fix:**
+
+```bash
+# Wrap in login shell:
+ssh test@<ip> 'bash -l -c "your-command-here"'
+
+# Or use full paths:
+ssh test@<ip> '/usr/local/bin/my-tool --version'
+```
+
+### Host key changes after clone deletion
+
+**Problem:** `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` when connecting to a new clone at the same IP.
+
+**Fix:**
+
+```bash
+ssh-keygen -R 192.168.64.5
+```
+
+Then connect again. This is expected — each clone gets a unique host key but may reuse the same DHCP IP.
+
+## SSH Config Shortcut
+
+Add to `~/.ssh/config` for convenience:
+
+```
+Host test-vm
+    HostName 192.168.64.5
+    User test
+    IdentitiesOnly yes
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+```
+
+**`StrictHostKeyChecking no` + `/dev/null`:** Suppresses host key warnings. Only use this for disposable test VMs — never for production.
+
+## File Transfer
+
+```bash
+# Copy file to VM:
+scp ./script.sh test@<ip>:~/
+
+# Copy directory to VM:
+scp -r ./my-project test@<ip>:~/
+
+# Copy file from VM:
+scp test@<ip>:~/output.log ./
+```
+
+## Port Forwarding (Optional)
+
+Forward a port from the VM to your host (e.g., test a web server running in the VM):
+
+```bash
+ssh -L 8080:localhost:8080 test@<ip>
+```
+
+Then access `http://localhost:8080` on your host to reach the VM's port 8080.

--- a/plugins/utm-testing/skills/utm-testing/references/testing-patterns.md
+++ b/plugins/utm-testing/skills/utm-testing/references/testing-patterns.md
@@ -1,0 +1,169 @@
+# Common Testing Workflows
+
+Generic patterns for testing software on UTM macOS VMs. Not coupled to any specific project — adapt these to whatever you're testing.
+
+## Pattern 1: Test a Shell Script / Installer
+
+Copy a local script to the VM and run it:
+
+```bash
+# Copy and run:
+scp ./install.sh test@<vm-ip>:~/
+ssh test@<vm-ip> 'chmod +x ~/install.sh && ~/install.sh'
+
+# Or curl from a remote URL:
+ssh test@<vm-ip> 'curl -fsSL https://example.com/install.sh | bash'
+```
+
+**Verify:**
+
+```bash
+ssh test@<vm-ip> 'echo "Exit code: $?"'
+ssh test@<vm-ip> 'which my-tool'  # Check if it installed
+```
+
+## Pattern 2: Test a Git Repo's Setup
+
+Clone a repo on the VM and run its setup script:
+
+```bash
+# Public repo:
+ssh test@<vm-ip> 'git clone https://github.com/user/repo.git ~/repo && cd ~/repo && ./setup.sh'
+
+# Private repo (use HTTPS + token or SSH key):
+ssh test@<vm-ip> 'git clone https://<token>@github.com/user/repo.git ~/repo'
+```
+
+**With login shell** (if setup needs Homebrew or other PATH-dependent tools):
+
+```bash
+ssh test@<vm-ip> 'bash -l -c "git clone https://github.com/user/repo.git ~/repo && cd ~/repo && ./setup.sh"'
+```
+
+## Pattern 3: Test Homebrew Packages / Brewfile
+
+```bash
+# Install Homebrew first (if not in base VM):
+ssh test@<vm-ip> 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+
+# Add to PATH:
+ssh test@<vm-ip> 'echo '\''eval "$(/opt/homebrew/bin/brew shellenv)"'\'' >> ~/.zshrc'
+
+# Install from Brewfile:
+scp ./Brewfile test@<vm-ip>:~/
+ssh test@<vm-ip> 'bash -l -c "brew bundle --file=~/Brewfile"'
+
+# Verify:
+ssh test@<vm-ip> 'bash -l -c "brew bundle check --file=~/Brewfile"'
+```
+
+## Pattern 4: Test macOS Defaults / Preferences
+
+```bash
+# Copy and run a defaults script:
+scp ./defaults.sh test@<vm-ip>:~/
+ssh test@<vm-ip> 'chmod +x ~/defaults.sh && ~/defaults.sh'
+
+# Verify a specific setting:
+ssh test@<vm-ip> 'defaults read com.apple.dock autohide'
+ssh test@<vm-ip> 'defaults read NSGlobalDomain AppleShowAllExtensions'
+
+# Verify pmset settings:
+ssh test@<vm-ip> 'pmset -g custom'
+```
+
+## Pattern 5: Test Unpushed Changes
+
+Push your branch first, then test on the VM:
+
+```bash
+# On your host:
+git push origin my-branch
+
+# On the VM:
+ssh test@<vm-ip> 'bash -l -c "git clone -b my-branch https://github.com/user/repo.git ~/repo && cd ~/repo && ./install.sh"'
+```
+
+Or copy the working directory directly:
+
+```bash
+# Sync local directory to VM (excludes .git, node_modules, etc.):
+rsync -avz --exclude='.git' --exclude='node_modules' ./ test@<vm-ip>:~/project/
+ssh test@<vm-ip> 'bash -l -c "cd ~/project && ./install.sh"'
+```
+
+## Pattern 6: Non-Interactive / CI-Style Testing
+
+Chain everything in one SSH command for fully automated testing:
+
+```bash
+ssh test@<vm-ip> 'bash -l -c "
+  set -euo pipefail
+  git clone https://github.com/user/repo.git ~/repo
+  cd ~/repo
+  ./setup.sh --ci
+  ./test.sh
+  echo PASSED
+"'
+```
+
+**Capture exit code:**
+
+```bash
+ssh test@<vm-ip> 'bash -l -c "cd ~/repo && ./test.sh"'
+echo "Exit code: $?"
+```
+
+## Pattern 7: Test a Dotfiles Repo
+
+```bash
+# Clone dotfiles and run install:
+ssh test@<vm-ip> 'bash -l -c "
+  git clone https://github.com/user/dotfiles.git ~/dotfiles
+  cd ~/dotfiles
+  ./install.sh
+"'
+
+# Verify symlinks:
+ssh test@<vm-ip> 'ls -la ~/.zshrc ~/.gitconfig ~/.config/'
+
+# Verify shell loads cleanly (no errors):
+ssh test@<vm-ip> 'bash -l -c "echo Shell loaded OK"'
+```
+
+## Verification Checklist
+
+After running your test, verify the results. Adapt this checklist to your project:
+
+```bash
+VM_IP="192.168.64.5"
+
+# Did the script succeed?
+ssh test@$VM_IP 'echo "Last exit code: $?"'
+
+# Are expected binaries installed?
+ssh test@$VM_IP 'which git node bun brew'
+
+# Are config files in place?
+ssh test@$VM_IP 'ls -la ~/.zshrc ~/.gitconfig'
+
+# Are symlinks correct?
+ssh test@$VM_IP 'readlink ~/.zshrc'
+
+# Are services running?
+ssh test@$VM_IP 'bash -l -c "brew services list"'
+
+# Are macOS defaults applied?
+ssh test@$VM_IP 'defaults read com.apple.dock autohide'
+
+# Is the PATH correct in a login shell?
+ssh test@$VM_IP 'bash -l -c "echo \$PATH"'
+```
+
+## Tips
+
+- **Always use `bash -l -c`** when the command depends on anything in `.zshrc` or `.zprofile`
+- **Use `set -euo pipefail`** in multi-line scripts to fail fast on errors
+- **Capture output** if you need to analyze it later: `ssh ... 'command' > output.log 2>&1`
+- **Use `NONINTERACTIVE=1`** for Homebrew install to skip prompts
+- **Check host key warnings** — after deleting and re-cloning, run `ssh-keygen -R <ip>` to clear old keys

--- a/plugins/utm-testing/skills/utm-testing/references/vm-setup.md
+++ b/plugins/utm-testing/skills/utm-testing/references/vm-setup.md
@@ -1,0 +1,103 @@
+# Creating the Base VM
+
+Step-by-step guide for creating a UTM macOS VM that serves as your golden image for clone-based testing.
+
+## Create the VM
+
+1. Open UTM → **Create a New Virtual Machine**
+2. Select **Virtualize** (not Emulate — native performance on Apple Silicon)
+3. Choose **macOS**
+4. Download or select an IPSW file
+   - Match your host macOS version for best compatibility
+   - UTM will offer to download the latest compatible IPSW
+5. Configure hardware:
+   - **CPU:** 4+ cores (recommended)
+   - **RAM:** 8GB+ (minimum 4GB, 8GB comfortable for most testing)
+   - **Disk:** 64GB+ (macOS alone uses ~15GB, leave room for software)
+6. Name it descriptively: `macOS-Tahoe-Base`, `macOS-Sequoia-Base`, etc.
+7. Click **Save** and start the VM
+
+## Complete macOS Setup Assistant
+
+1. Select language and region
+2. Skip Apple ID sign-in (not needed for testing)
+3. Create a local user account:
+   - **Username:** `test` (or whatever you prefer)
+   - **Password:** Keep it simple for dev/testing (e.g., `test`)
+   - You'll type this password over SSH, so short is fine
+4. Skip all optional setup (Siri, analytics, Screen Time, etc.)
+5. Complete setup and reach the desktop
+
+## Pre-Clone Checklist (CRITICAL)
+
+Do these **before** your first clone. UTM has no snapshots — the clone IS your baseline. If something isn't working in the base VM, every clone inherits the problem.
+
+### Required
+
+1. **Enable Remote Login (SSH)**
+   - System Settings → General → Sharing → Remote Login → **ON**
+   - Allow access for: your user account (or All Users for simplicity)
+
+2. **Verify SSH works**
+   ```bash
+   # Inside the VM, get the IP:
+   ipconfig getifaddr en0
+
+   # From your host Mac, test SSH:
+   ssh test@<vm-ip>
+   ```
+
+### Recommended
+
+3. **Install Xcode Command Line Tools**
+   ```bash
+   xcode-select --install
+   ```
+   Saves 5-10 minutes on every clone that needs git, clang, or developer tools.
+
+4. **Install Rosetta** (if testing x86 software on Apple Silicon)
+   ```bash
+   softwareupdate --install-rosetta --agree-to-license
+   ```
+
+5. **Install Homebrew** (if most tests will need it)
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+   Add to PATH:
+   ```bash
+   echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
+   ```
+
+6. **Set up passwordless sudo** (optional, for automated testing)
+   ```bash
+   sudo visudo
+   # Add: test ALL=(ALL) NOPASSWD: ALL
+   ```
+
+### Optional
+
+7. **Disable sleep/screen saver** (prevents SSH disconnects during long tests)
+   - System Settings → Lock Screen → set all timers to Never
+   - Or via CLI: `sudo pmset -a disablesleep 1`
+
+8. **Reduce disk usage** — remove unused apps, disable Spotlight indexing:
+   ```bash
+   sudo mdutil -a -i off
+   ```
+
+## Multiple Base VMs
+
+Create purpose-specific bases if your testing needs vary:
+
+| Base VM | Pre-installed | Use For |
+|---------|---------------|---------|
+| `macOS-Base-Bare` | SSH only | Installer testing, first-run experience |
+| `macOS-Base-Dev` | SSH + Xcode CLT + Homebrew | Dev tool testing, Brewfile validation |
+| `macOS-Base-Full` | SSH + Xcode CLT + Homebrew + common tools | Complex setup testing |
+
+## Maintenance
+
+- **Update the base periodically** — macOS updates, Homebrew updates, Xcode CLT updates
+- **After updating the base**, delete old clones and create fresh ones
+- **Keep the base VM shut down** when not actively configuring it


### PR DESCRIPTION
## Summary

- Adds `utm-testing` plugin — a pure-skill plugin that teaches Claude Code how to set up UTM macOS VMs, SSH into them, and use clone-based workflows for testing anything on a fresh macOS environment
- Moves `bun-starter` plugin from side-quest-marketplace (restored from git history after removal in `5d90a38`). Dropped `package.json`, updated repo URL and internal references.

## Changes

### utm-testing (new, 6 files)
- `SKILL.md` — workflow overview, quick-reference checklist, trigger phrases
- `references/vm-setup.md` — base VM creation, hardware config, pre-clone checklist
- `references/ssh-access.md` — SSH patterns, PATH issues, host key gotchas, file transfer
- `references/clone-workflow.md` — APFS clone-as-snapshot, CoW rules, multiple bases
- `references/testing-patterns.md` — 7 testing patterns (installers, git repos, Homebrew, dotfiles, CI-style)

### bun-starter (moved, 19 files)
- 3 commands (`create`, `fix`, `sync`)
- 2 skills (`bun-starter-expert`, `heal-template`)
- 13 reference docs (architecture, CI/CD, publishing, testing, etc.)
- Removed `package.json` (not needed in side-quest-plugins)
- Updated repository URL and internal references from marketplace to plugins repo

## Test plan

- [x] `claude plugin validate plugins/utm-testing` passes
- [x] `claude plugin validate plugins/bun-starter` passes
- [x] Pre-commit hooks (Biome lint) pass
- [ ] Invoke `/utm-testing:utm-testing` in a Claude Code session
- [ ] Invoke `/bun-starter:create` in a Claude Code session