### PR TITLE
chore: sync infrastructure from bun-typescript-starter

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,13 +2,14 @@ name: Commitlint
 on:
   pull_request:
     types: [opened, synchronize, edited, reopened]
+  push:
+    branches: [main]
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 permissions:
   contents: read
   actions: read
-  pull-requests: read
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -15,6 +15,8 @@ concurrency:
 permissions:
   contents: read
   actions: read
+  checks: write
+  pull-requests: write
 
 jobs:
   lint:
@@ -34,6 +36,24 @@ jobs:
 
       - name: Biome lint
         run: bun run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Standard env
+        uses: ./.github/actions/standard-ci-env
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: TSC typecheck
+        run: bun run typecheck
 
   lint-scripts:
     name: Lint Shell Scripts
@@ -57,7 +77,7 @@ jobs:
   gate:
     name: All checks passed
     runs-on: ubuntu-latest
-    needs: [lint, lint-scripts]
+    needs: [lint, typecheck, lint-scripts]
     timeout-minutes: 5
     steps:
       - name: Aggregate result
@@ -72,5 +92,6 @@ jobs:
             echo "| Check | Status |"
             echo "|---|---|"
             echo "| Lint | ${{ needs.lint.result }} |"
+            echo "| Typecheck | ${{ needs.typecheck.result }} |"
             echo "| Lint Shell Scripts | ${{ needs.lint-scripts.result }} |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -30,10 +30,8 @@ jobs:
 
       - name: Install actionlint
         run: |
-          curl -sSLO "https://github.com/rhysd/actionlint/releases/download/v1.7.10/actionlint_1.7.10_linux_amd64.tar.gz"
-          echo "f4c76b71db5755a713e6055cbb0857ed07e103e028bda117817660ebadb4386f  actionlint_1.7.10_linux_amd64.tar.gz" | sha256sum -c
-          tar xzf actionlint_1.7.10_linux_amd64.tar.gz actionlint
-          echo "$PWD" >> "$GITHUB_PATH"
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          pwd >> "$GITHUB_PATH"
 
       - name: Run actionlint
         run: actionlint -color -oneline .github/workflows/*.yml

--- a/bun.lock
+++ b/bun.lock
@@ -8,8 +8,10 @@
         "@biomejs/biome": "^2.3.7",
         "@commitlint/cli": "^20.1.0",
         "@commitlint/config-conventional": "^20.0.0",
+        "bun-types": "^1.3.8",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.10",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -89,6 +91,8 @@
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,14 +29,17 @@
 		"format:check": "biome format .",
 		"lint": "biome lint .",
 		"lint:fix": "biome lint --write .",
+		"typecheck": "tsc --noEmit",
 		"prepare": "husky"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.7",
 		"@commitlint/cli": "^20.1.0",
 		"@commitlint/config-conventional": "^20.0.0",
+		"bun-types": "^1.3.8",
 		"husky": "^9.1.7",
-		"lint-staged": "^15.2.10"
+		"lint-staged": "^15.2.10",
+		"typescript": "^5.9.3"
 	},
 	"lint-staged": {
 		"*.{ts,tsx,js,jsx,mts,cts,json}": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.base.json",
+	"include": ["plugins/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Sync 3 workflow files from upstream `bun-typescript-starter` template
- Add TypeScript type checking to CI pipeline (Biome lint was already in place)
- Strip test/coverage/quality jobs (not needed for this plugins repo)

### Changes

- **commitlint.yml** - add `push` trigger for main, remove redundant permission
- **workflow-lint.yml** - simplify actionlint install via upstream script
- **pr-quality.yml** - add `typecheck` job, gate now requires lint + typecheck + lint-scripts
- **tsconfig.json** - new root config extending `tsconfig.base.json`, includes `plugins/**/*.ts` and `scripts/**/*.ts`
- **package.json** - add `typecheck` script, `typescript` and `bun-types` devDeps

## Test plan

- [x] `bun run lint` passes (Biome)
- [x] `bun run typecheck` passes (tsc --noEmit)
- [x] Pre-commit hook runs lint-staged correctly
- [ ] CI workflows pass on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated type checking capabilities
  * Updated development dependencies and build tools
  * Streamlined workflow automation processes for improved code quality verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->