### PR TITLE
feat(bun-typescript-starter): add branch protection drift check to sync command

### DIFF
--- a/plugins/bun-typescript-starter/commands/sync.md
+++ b/plugins/bun-typescript-starter/commands/sync.md
@@ -226,7 +226,7 @@ After applying changes:
    | Setting | Expected Value |
    |---------|---------------|
    | `required_status_checks.strict` | `true` |
-   | `required_status_checks.contexts` | Must include `All checks passed` and `CodeRabbit` |
+   | `required_status_checks.checks` | Must include `{"context": "All checks passed"}` and `{"context": "CodeRabbit"}` |
    | `enforce_admins.enabled` | `true` |
    | `required_pull_request_reviews.dismiss_stale_reviews` | `true` |
    | `required_pull_request_reviews.required_approving_review_count` | `0` |


### PR DESCRIPTION
## Summary

- Add branch protection drift detection to `/bun-typescript-starter:sync`
- Compares downstream repo's actual branch protection against the template's expected settings
- Detects missing required status checks (e.g. CodeRabbit), disabled conversation resolution, and other settings drift
- Offers to fix drift automatically via `gh api`

This closes the gap where file sync catches workflow/config drift but branch protection settings could silently diverge from the template's intended configuration.

### Expected settings checked

| Setting | Expected |
|---------|----------|
| Required status checks | `All checks passed` + `CodeRabbit` |
| Strict status checks | `true` |
| Enforce admins | `true` |
| Dismiss stale reviews | `true` |
| Required conversation resolution | `true` |
| Linear history | `true` |
| Force pushes | `false` |
| Deletions | `false` |

## Test plan

- [ ] Run `/bun-typescript-starter:sync` on a downstream repo and verify drift is reported
- [ ] Verify "Fix all" option applies the correct branch protection payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated sync command docs with a new branch protection drift check that compares current vs expected settings.
  * Adds a concise drift report showing only differing rules and interactive prompts to apply fixes or skip.
  * Now guides users through setting up branch protection when none is detected and preserves the existing "Suggest next steps" section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->