### PR TITLE
feat(kit): add Kit CLI code intelligence plugin

### DIFF
--- a/plugins/kit/.claude-plugin/plugin.json
+++ b/plugins/kit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+	"name": "kit",
+	"description": "Kit CLI integration for intelligent code search, semantic analysis, and context engineering. 7 MCP tools with priority hierarchy for token efficiency.",
+	"version": "1.0.0",
+	"author": {
+		"name": "Nathan Vale"
+	}
+}

--- a/plugins/kit/.mcp.json
+++ b/plugins/kit/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"kit": {
+			"command": "bunx",
+			"args": ["--bun", "@side-quest/kit"]
+		}
+	}
+}

--- a/plugins/kit/commands/chunk.md
+++ b/plugins/kit/commands/chunk.md
@@ -1,0 +1,35 @@
+---
+description: Split a file into LLM-friendly chunks
+argument-hint: <file-path> [--strategy symbols|lines] [--max-lines N]
+model: claude-haiku-4-5-20251001
+---
+
+# Chunk File for LLM Processing
+
+Split a file into chunks at function boundaries or by line count.
+
+## Your Task
+
+Execute kit_chunk with the provided arguments: $ARGUMENTS
+
+Parse arguments:
+- First arg: file path (e.g., `src/kit-wrapper.ts`)
+- `--strategy symbols|lines` -- Chunking strategy (default: symbols)
+- `--max-lines N` -- Max lines per chunk (only for lines strategy, default: 50)
+
+Use the MCP tool:
+```
+kit_chunk({
+  file_path: "<path>",
+  strategy: "symbols",  // or "lines"
+  max_lines: 50,         // only for lines strategy
+  response_format: "json"
+})
+```
+
+What happens:
+- **symbols** strategy: Splits at function/class boundaries (semantic chunking)
+- **lines** strategy: Splits by line count (configurable)
+- Returns chunks with metadata (name, line ranges, content)
+
+Display the chunks with their metadata.

--- a/plugins/kit/commands/context.md
+++ b/plugins/kit/commands/context.md
@@ -1,0 +1,29 @@
+---
+description: Extract full enclosing definition around a file:line
+argument-hint: <file-path> <line-number>
+model: claude-haiku-4-5-20251001
+---
+
+# Extract Code Context
+
+Extract the full enclosing function/class/method around a specific line.
+
+## Your Task
+
+Execute kit_context with the provided arguments: $ARGUMENTS
+
+Parse arguments:
+- First arg: file path (e.g., `src/kit-wrapper.ts`)
+- Second arg: line number (e.g., `42`)
+
+Use the MCP tool:
+```
+kit_context({ file_path: "<path>", line: <number>, response_format: "json" })
+```
+
+What happens:
+- Kit CLI finds the enclosing definition (function, class, method) containing the line
+- Returns the complete definition body with context
+- Much more efficient than reading the entire file
+
+Display the extracted context with syntax highlighting.

--- a/plugins/kit/commands/find.md
+++ b/plugins/kit/commands/find.md
@@ -1,0 +1,27 @@
+---
+description: Find symbol definitions or list file symbols from the index
+argument-hint: <symbol-name|file-path>
+model: claude-haiku-4-5-20251001
+---
+
+# Find Symbol or File Overview
+
+Find where a symbol is defined, or list all symbols in a file, using PROJECT_INDEX.json.
+
+## Your Task
+
+Execute kit_find with the provided arguments: $ARGUMENTS
+
+Determine mode from arguments:
+- If argument looks like a file path (contains `/` or `.ts`/`.js`/`.py`): use file_path mode
+- Otherwise: use symbol_name mode
+
+Use the MCP tool:
+- `kit_find({ symbol_name: "<name>", response_format: "json" })` -- find symbol definition
+- `kit_find({ file_path: "<path>", response_format: "json" })` -- list all symbols in file
+
+What happens:
+- Symbol mode: Exact match, then fuzzy fallback
+- File mode: Returns all functions, classes, types with line numbers
+
+Display results showing definitions found or file structure.

--- a/plugins/kit/commands/logs.md
+++ b/plugins/kit/commands/logs.md
@@ -1,0 +1,35 @@
+---
+description: View Kit plugin logs for debugging
+argument-hint: [lines?] [correlation-id?]
+model: claude-haiku-4-5-20251001
+---
+
+# Kit Logs Command
+
+View and filter JSONL logs from the Kit MCP server.
+
+## Your Task
+
+View Kit MCP server logs with optional filtering: $ARGUMENTS
+
+Log file location: `~/.claude/logs/kit.jsonl`
+
+### Parse Arguments:
+- No arguments -- Show last 20 entries
+- Number (e.g., `50`) -- Show last N entries
+- String (e.g., `a1b2c3d4`) -- Filter by correlation ID
+
+### Commands to use:
+
+```bash
+# Default: last 20 lines
+tail -20 ~/.claude/logs/kit.jsonl | jq -r '.["@timestamp"] + " [" + .["@level"] + "] " + .["@category"] + ": " + .["@message"]'
+
+# Last N lines
+tail -N ~/.claude/logs/kit.jsonl | jq -r '.["@timestamp"] + " [" + .["@level"] + "] " + .["@category"] + ": " + .["@message"]'
+
+# Filter by correlation ID
+jq -r 'select(.cid == "CORRELATION_ID") | .["@timestamp"] + " [" + .["@level"] + "] " + .["@category"] + ": " + .["@message"]' ~/.claude/logs/kit.jsonl
+```
+
+Present logs showing timestamp, level, category, and message. If the file doesn't exist, inform the user no logs have been generated yet.

--- a/plugins/kit/commands/prime.md
+++ b/plugins/kit/commands/prime.md
@@ -1,0 +1,28 @@
+---
+description: Generate or refresh PROJECT_INDEX.json for fast codebase queries
+argument-hint: [path] [--force]
+model: claude-haiku-4-5-20251001
+---
+
+# Prime the Codebase Index
+
+Generate PROJECT_INDEX.json to enable token-efficient codebase queries.
+
+## Your Task
+
+Run kit_prime with any provided arguments: $ARGUMENTS
+
+Use the MCP tool:
+- `kit_prime({ response_format: "json" })` -- default, index current repo
+- `kit_prime({ path: "<dir>", response_format: "json" })` -- index specific directory
+- `kit_prime({ force: true, response_format: "json" })` -- force regenerate
+
+If no arguments, run with defaults. Parse `--force` flag from arguments.
+
+What happens:
+- Auto-detects git repository root
+- Checks for existing index (skips if fresh < 24h)
+- Generates new index if missing, stale, or `--force` used
+- Reports file count, symbol count, and index size
+
+Display the results showing index status.

--- a/plugins/kit/skills/code-intelligence/SKILL.md
+++ b/plugins/kit/skills/code-intelligence/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: code-intelligence
+description: Code intelligence expert -- finds symbols, traces references, analyzes impact, searches by structure or meaning. Orchestrates Kit MCP tools with priority hierarchy for token efficiency.
+user-invocable: true
+disable-model-invocation: false
+context: shared
+allowed-tools:
+  - mcp__plugin_kit_kit__kit_prime
+  - mcp__plugin_kit_kit__kit_find
+  - mcp__plugin_kit_kit__kit_references
+  - mcp__plugin_kit_kit__kit_semantic
+  - mcp__plugin_kit_kit__kit_ast_search
+  - mcp__plugin_kit_kit__kit_context
+  - mcp__plugin_kit_kit__kit_chunk
+  - Bash(kit *)
+  - Read
+  - Glob
+  - Grep
+triggers:
+  - code search
+  - find definition
+  - symbol lookup
+  - who calls
+  - blast radius
+  - dead code
+  - semantic search
+  - ast search
+---
+
+# Code Intelligence Expert
+
+You are a code intelligence agent that helps users understand and navigate codebases efficiently using Kit CLI tools. You orchestrate 7 MCP tools in a priority hierarchy to minimize token usage and response latency.
+
+## Tool Priority Hierarchy
+
+ALWAYS follow this order -- faster/cheaper tools first:
+
+### Priority 1: Index Tools (~10ms)
+- **kit_prime** -- Generate/refresh PROJECT_INDEX.json (run once per session)
+- **kit_find** -- Symbol lookup or file overview from the index
+
+### Priority 2: Reference Tools (~200ms)
+- **kit_references** -- Find callers, usages, definitions
+
+### Priority 3: Search Tools (~500ms)
+- **kit_ast_search** -- Structural search (find all async functions, try-catch blocks)
+- **kit_semantic** -- Natural language search (requires ML deps)
+
+### Priority 4: Context Tools (~500ms)
+- **kit_context** -- Extract full enclosing definition around a file:line
+- **kit_chunk** -- Split file into LLM-friendly chunks
+
+## Routing Table
+
+| User Question | Tool | Parameters |
+|---------------|------|------------|
+| "Where is X defined?" | kit_find | symbol_name: "X" |
+| "What's in this file?" | kit_find | file_path: "path/to/file.ts" |
+| "Who calls X?" | kit_references | symbol: "X", mode: "callers_only" |
+| "Where is X used?" | kit_references | symbol: "X", mode: "all" |
+| "Find async functions" | kit_ast_search | pattern: "async function" |
+| "How does auth work?" | kit_semantic | query: "authentication flow" |
+| "Show context around line 42" | kit_context | file_path: "file.ts", line: 42 |
+| "Chunk this large file" | kit_chunk | file_path: "file.ts", strategy: "symbols" |
+
+## Setup
+
+Before using index-based tools, ensure the index exists:
+
+```
+kit_prime (run once per session, valid for 24 hours)
+```
+
+If a tool returns "PROJECT_INDEX.json not found", run kit_prime first.
+
+## Analysis Workflows
+
+For complex analysis that goes beyond single tool calls, use the Kit CLI directly via Bash:
+
+### Dead Code Detection
+```bash
+kit dead [path]
+```
+
+### Blast Radius Analysis
+```bash
+kit blast <file:line|symbol>
+```
+
+### API Surface Listing
+```bash
+kit api <directory>
+```
+
+### Codebase Statistics
+```bash
+kit stats
+```
+
+## Context Assembly
+
+When the user needs to understand a specific area of code:
+
+1. **Start with kit_find** (file overview mode) to see all symbols in the file
+2. **Zoom in with kit_context** to get the full definition around a specific line
+3. **Trace references with kit_references** to understand how it connects to other code
+4. **Chunk large files with kit_chunk** if the file is too big to read at once
+
+## Response Format
+
+ALWAYS use `response_format: "json"` for all MCP tool calls -- this saves 40-60% tokens compared to markdown format.
+
+## Error Handling
+
+- If Kit CLI is not installed: "Kit CLI required. Install with: uv tool install cased-kit"
+- If ML deps missing (semantic): "Semantic search requires ML deps. Install with: uv tool install 'cased-kit[ml]'"
+- If index missing: Run kit_prime automatically, then retry the original operation


### PR DESCRIPTION
## Summary

- Adds Kit CLI code intelligence plugin wrapper for `@side-quest/kit` npm package
- MCP server runs via `bunx --bun @side-quest/kit` (7 focused tools)
- Includes code-intelligence skill with tool priority hierarchy
- 5 slash commands: prime, find, logs, context, chunk

## Test plan

- [ ] Verify `bunx --bun @side-quest/kit` starts MCP server after npm publish
- [ ] Skill loads: `/kit:code-intelligence` appears in skill list
- [ ] Commands load: `/kit:prime`, `/kit:find`, `/kit:logs`, `/kit:context`, `/kit:chunk`
- [ ] MCP tools accessible: kit_prime, kit_find, kit_references, kit_semantic, kit_ast_search, kit_context, kit_chunk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Kit plugin enabling code intelligence capabilities including semantic symbol search, code context extraction, and intelligent file chunking for LLM processing.

* **Documentation**
  * Added guides for Kit commands (chunk, context, find, logs, prime) and code-intelligence skill configuration.

* **Chores**
  * Added plugin manifest and MCP server configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->