### PR TITLE
docs(bun-starter): document GitHub App token anti-recursion fix

### DIFF
--- a/plugins/bun-typescript-starter/references/ci-cd-pipelines.md
+++ b/plugins/bun-typescript-starter/references/ci-cd-pipelines.md
@@ -71,6 +71,8 @@ Four intents via `workflow_dispatch`:
 
 Uses OIDC trusted publishing (npm 11.6+ on Node 24). Falls back to `NPM_TOKEN` secret.
 
+**GitHub App token (anti-recursion bypass)**: `publish.yml` uses a 1Password-sourced GitHub App token instead of `GITHUB_TOKEN` for all git operations. This is critical because `GITHUB_TOKEN` pushes don't trigger `pull_request_target` events (GitHub's anti-recursion policy), which would prevent `version-packages-auto-merge.yml` from firing on version packages PRs. The App token bypasses this, completing the automated release chain: publish -> version PR -> auto-merge -> publish.
+
 **Registry conflict fix**: Removes `bunfig.toml` registry entry that conflicts with npm's auth:
 ```yaml
 - name: Fix bunfig registry conflict
@@ -104,7 +106,7 @@ All 17 workflows follow these patterns:
 |--------|---------|---------|
 | `GITHUB_TOKEN` | Most workflows | Default GitHub token |
 | `NPM_TOKEN` | publish, release, alpha-snapshot | npm auth (fallback for OIDC) |
-| `OP_SERVICE_ACCOUNT_TOKEN` | release, version-packages-auto-merge | 1Password GitHub App credentials |
+| `OP_SERVICE_ACCOUNT_TOKEN` | publish, release, version-packages-auto-merge | 1Password GitHub App credentials |
 
 ## Composite Actions
 

--- a/plugins/bun-typescript-starter/references/troubleshooting.md
+++ b/plugins/bun-typescript-starter/references/troubleshooting.md
@@ -62,6 +62,8 @@ Master routing table for diagnosing issues in repos created from `nathanvale/bun
 | "All checks passed" status missing | Gate job didn't run | Ensure `gate` job depends on all other jobs | `pr-quality.yml` |
 | Dependabot PR not auto-merging | Missing label | Add `dev-dependencies` label | `dependabot-auto-merge.yml` |
 | Auto-merge fails on version PR | Needs elevated permissions | Configure 1Password + GitHub App | `version-packages-auto-merge.yml` |
+| Version PR created but auto-merge never triggers | `publish.yml` uses `GITHUB_TOKEN` -- pushes don't fire `pull_request_target` (GitHub anti-recursion) | Replace `secrets.GITHUB_TOKEN` with App token from 1Password in `publish.yml` (add `load-secrets-action` + `create-github-app-token` steps, replace all `GITHUB_TOKEN` env refs with `steps.app-token.outputs.token`) | `publish.yml` |
+| `OP_SERVICE_ACCOUNT_TOKEN` empty in CI | Secret set but env var shows blank | Re-set secret from 1Password: `op item get <id> --vault="API Credentials" --fields label=credential --reveal \| gh secret set OP_SERVICE_ACCOUNT_TOKEN` | GitHub repo secrets |
 | CodeQL timeout | Analysis too slow | Increase timeout or exclude dirs | `codeql.yml` |
 | SBOM not generated | anchore/sbom-action issue | Check action version is pinned to valid SHA | `release.yml` |
 | `Cannot find module '@scope/pkg/subpath'` in CI | Cleanup step deletes `node_modules/.bun` | Remove `node_modules/.bun` from `rm -rf` in cleanup steps | `publish.yml`, `pr-quality.yml` |


### PR DESCRIPTION
## Summary

Update bun-typescript-starter expert skill references to document the GitHub App token pattern in `publish.yml` that fixes the auto-merge chain.

## Changes

- **ci-cd-pipelines.md**: Document App token usage in `publish.yml`, update secrets table
- **publishing.md**: Add troubleshooting entry for version PR auto-merge not triggering
- **troubleshooting.md**: Add routing table entries for anti-recursion and OP_SERVICE_ACCOUNT_TOKEN issues

## Context

Discovered while dogfooding the template in `side-quest-kit`. The skill needs to know about this fix so it can diagnose the issue in future downstream repos.