### PR TITLE
feat(plugins): add community intel infrastructure for knowledge-bank skills

### DIFF
--- a/plugins/claude-code/skills/hooks/references/verified-intel.md
+++ b/plugins/claude-code/skills/hooks/references/verified-intel.md
@@ -1,0 +1,4 @@
+# Verified Community Intelligence
+
+Curated findings from community sources, reviewed and accepted.
+Entries persist permanently - this is accumulative knowledge.

--- a/plugins/dell-u4025qw/community-intel.json
+++ b/plugins/dell-u4025qw/community-intel.json
@@ -1,0 +1,13 @@
+{
+	"topics": [
+		"Dell U4025QW firmware update issues",
+		"Dell U4025QW macOS color calibration Display P3 settings",
+		"Dell U4025QW KVM switching multiple Mac computers",
+		"Dell U4025QW sleep wake disconnect Thunderbolt macOS",
+		"Dell U4025QW BetterDisplay Lunar MonitorControl m1ddc macOS",
+		"Dell U4025QW HiDPI scaling resolution macOS"
+	],
+	"refreshIntervalDays": 30,
+	"thinCacheIntervalDays": 7,
+	"context": "Knowledge-bank skill for the Dell U4025QW 40-inch curved Thunderbolt hub monitor. Focus on firmware updates, macOS compatibility, KVM switching, sleep/wake issues, DDC automation, HiDPI scaling, and software tools."
+}

--- a/plugins/dell-u4025qw/skills/dell-u4025qw/references/verified-intel.md
+++ b/plugins/dell-u4025qw/skills/dell-u4025qw/references/verified-intel.md
@@ -1,0 +1,4 @@
+# Verified Community Intelligence
+
+Curated findings from community sources, reviewed and accepted.
+Entries persist permanently - this is accumulative knowledge.


### PR DESCRIPTION
## Summary

- Add `verified-intel.md` placeholder templates for claude-code hooks and dell-u4025qw skills to persist curated community findings
- Add `community-intel.json` config for dell-u4025qw with monitor-specific research topics and refresh intervals (30-day refresh, 7-day thin cache)

## Test plan

- [ ] Verify knowledge-bank skills can read from the new verified-intel.md files
- [ ] Verify community-intel.json topics are picked up by the research refresh workflow