### PR TITLE
fix(hooks): harden git safety guards and rewrite SessionStart context loader

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -15,6 +15,8 @@ Provides intelligent git context, history exploration, smart commit capabilities
 
 **PreToolUse** - Git safety guard:
 - Blocks destructive commands (force push, hard reset, clean -f, checkout ., branch -D)
+- Blocks all commits on protected branches (main/master)
+- Blocks --no-verify on non-WIP commits (prevents bypassing pre-commit hooks)
 - Blocks Write/Edit to protected files (.env, credentials, .git/ directory)
 - Returns deny decision with explanation
 
@@ -28,9 +30,10 @@ Provides intelligent git context, history exploration, smart commit capabilities
 - Saves git state summary (append, not overwrite)
 
 **Stop** - Auto-commit check:
-- Creates WIP checkpoint for uncommitted tracked changes
+- Creates WIP checkpoint for uncommitted tracked changes (feature branches only)
 - Uses --no-verify to bypass pre-commit hooks
 - Uses git add -u (tracked files only, avoids staging secrets)
+- Skips on protected branches (main/master) to prevent direct commits
 
 ### Slash Commands
 

--- a/plugins/git/hooks/auto-commit-on-stop.ts
+++ b/plugins/git/hooks/auto-commit-on-stop.ts
@@ -10,6 +10,8 @@ import { readFile } from 'node:fs/promises'
 import type { FileStatusCounts } from './git-status-parser'
 import { parsePorcelainStatus } from './git-status-parser'
 
+const PROTECTED_BRANCHES = ['main', 'master']
+
 interface StopHookInput {
 	cwd: string
 	transcript_path: string
@@ -28,6 +30,19 @@ async function runGit(
 	const stdout = await new Response(proc.stdout).text()
 	const exitCode = await proc.exited
 	return { stdout, exitCode }
+}
+
+/** Returns the current branch name, or null if not in a git repo. */
+export async function getCurrentBranch(cwd: string): Promise<string | null> {
+	try {
+		const result = await runGit(['branch', '--show-current'], cwd)
+		if (result.exitCode !== 0) {
+			return null
+		}
+		return result.stdout.trim() || null
+	} catch {
+		return null
+	}
 }
 
 export async function getGitStatus(
@@ -125,6 +140,12 @@ if (import.meta.main) {
 		}
 
 		if (status.staged === 0 && status.modified === 0) {
+			process.exit(0)
+		}
+
+		// Skip WIP checkpoint on protected branches
+		const branch = await getCurrentBranch(input.cwd)
+		if (branch && PROTECTED_BRANCHES.includes(branch)) {
 			process.exit(0)
 		}
 

--- a/plugins/git/hooks/git-context-loader.ts
+++ b/plugins/git/hooks/git-context-loader.ts
@@ -3,14 +3,31 @@
 /**
  * Git Context Loader Hook
  *
- * SessionStart hook that loads git context at startup.
+ * SessionStart hook that injects git repository context into Claude's
+ * conversation. Fires on startup, resume, compact, and clear to ensure
+ * Claude always has current branch/status awareness and knows how to
+ * route git tasks.
+ *
+ * Output: Plain stdout text (avoids plugin hooks.json bug #16538 where
+ * hookSpecificOutput.additionalContext is silently discarded). Structured as:
+ * - Git Repository Context (branch, status, recent commits)
+ * - Git Command Routing (when to use each slash command)
+ * - Git Rules (safety constraints for git operations)
  */
 
 import { parsePorcelainStatus } from './git-status-parser'
 
+type SessionSource = 'startup' | 'resume' | 'compact' | 'clear'
+
 interface SessionStartHookInput {
+	session_id: string
+	hook_event_name: string
 	cwd: string
-	source: string
+	source: SessionSource
+	model: string
+	permission_mode: string
+	transcript_path?: string
+	agent_type?: string
 }
 
 interface GitContext {
@@ -42,7 +59,11 @@ async function isGitRepo(cwd: string): Promise<boolean> {
 	return exitCode === 0
 }
 
-async function getGitContext(cwd: string): Promise<GitContext | null> {
+/** Gathers git state. Uses fewer commits on compact/clear to save context budget. */
+export async function getGitContext(
+	cwd: string,
+	commitCount: number = 5,
+): Promise<GitContext | null> {
 	if (!(await isGitRepo(cwd))) {
 		return null
 	}
@@ -55,7 +76,7 @@ async function getGitContext(cwd: string): Promise<GitContext | null> {
 	const { branch, counts } = parsePorcelainStatus(statusResult.stdout)
 
 	const commitsResult = await runGit(
-		['log', '--oneline', '-5', '--format=%h %s (%ar)'],
+		['log', '--oneline', `-${commitCount}`, '--format=%h %s (%ar)'],
 		cwd,
 	)
 
@@ -74,35 +95,56 @@ async function getGitContext(cwd: string): Promise<GitContext | null> {
 	}
 }
 
-function formatContext(context: GitContext): string {
+/** Formats the additionalContext payload with role framing and routing hints. */
+export function formatAdditionalContext(
+	context: GitContext,
+	source: SessionSource,
+): string {
 	const { branch, status, recentCommits } = context
-	let output = 'Git Context:\n'
-	output += `  Branch: ${branch}\n`
-	output += `  Status: ${status.staged} staged, ${status.modified} modified, ${status.untracked} untracked\n`
-	output += '\nRecent commits:\n'
+	const sections: string[] = []
+
+	// Section 1: Repository state
+	const restoredNote =
+		source === 'compact' ? ' (restored after compaction)' : ''
+	let state = `## Git Repository Context${restoredNote}\n\n`
+	state += `Branch: ${branch}\n`
+	state += `Status: ${status.modified} modified, ${status.untracked} untracked, ${status.staged} staged\n`
 
 	if (recentCommits.length > 0) {
+		state += `\nRecent commits:\n`
 		for (const commit of recentCommits) {
-			output += `  ${commit}\n`
+			state += `- ${commit}\n`
 		}
 	} else {
-		output += '  (no commits yet)\n'
+		state += '\nNo commits yet.\n'
 	}
 
-	output += '\nGit workflow: /git:commit, /git:squash, /git:checkpoint'
-	output +=
-		'\ngit-expert skill handles: commits, PRs, history, worktrees, changelog, branch compare, squash, safety guards'
+	sections.push(state)
 
-	return output
-}
+	// Section 2: Command routing -- tells Claude WHEN to use each command
+	let routing = '## Git Command Routing\n\n'
+	routing += '| Need | Command |\n'
+	routing += '|------|--------|\n'
+	routing +=
+		'| Commit changes | /git:commit (analyzes diff, conventional commit) |\n'
+	routing += '| Quick save | /git:checkpoint (WIP commit, skips hooks) |\n'
+	routing +=
+		'| Squash WIP commits | /git:squash (combines into one clean commit) |\n'
+	routing += '| Create PR | /git:create-pr (push + gh pr create) |\n'
+	routing +=
+		'| Anything else git | git-expert skill (history, worktrees, changelog, compare, review) |'
+	sections.push(routing)
 
-function formatSystemMessage(context: GitContext): string {
-	const { branch, status, recentCommits } = context
-	const totalChanges = status.staged + status.modified + status.untracked
-	const changesSuffix = totalChanges > 0 ? `, ${totalChanges} changes` : ''
-	const lastCommit =
-		recentCommits[0]?.split(' ').slice(1).join(' ') || 'no commits'
-	return `Git: ${branch}${changesSuffix} | Last: ${lastCommit} | /git:commit /git:squash /git:checkpoint`
+	// Section 3: Safety rules -- critical after compaction when Claude loses memory
+	let rules = '## Git Rules\n\n'
+	rules += '- NEVER force push, hard reset, clean -f, or checkout/restore .\n'
+	rules += '- NEVER commit to main/master -- create a feature branch first\n'
+	rules += '- NEVER use git add . or git add -A -- stage specific files\n'
+	rules += '- ALWAYS use conventional commits: type(scope): subject\n'
+	rules += '- ALWAYS use HEREDOC for commit messages'
+	sections.push(rules)
+
+	return sections.join('\n\n')
 }
 
 if (import.meta.main) {
@@ -114,19 +156,27 @@ if (import.meta.main) {
 			process.exit(0)
 		}
 
-		if (input.source === 'startup') {
-			const context = await getGitContext(input.cwd)
-			if (context) {
-				console.log(
-					JSON.stringify({
-						systemMessage: formatSystemMessage(context),
-						hookSpecificOutput: {
-							hookEventName: 'SessionStart',
-							additionalContext: formatContext(context),
-						},
-					}),
-				)
-			}
+		const relevantSources: SessionSource[] = [
+			'startup',
+			'resume',
+			'compact',
+			'clear',
+		]
+		if (!relevantSources.includes(input.source as SessionSource)) {
+			process.exit(0)
+		}
+
+		const commitCount =
+			input.source === 'compact' || input.source === 'clear' ? 3 : 5
+		const context = await getGitContext(input.cwd, commitCount)
+		if (context) {
+			// Use plain stdout instead of JSON hookSpecificOutput.additionalContext.
+			// Plugin hooks.json has a known bug (#16538) where additionalContext
+			// is silently discarded. Plain stdout is reliably injected as context
+			// for SessionStart hooks regardless of source (plugin or user config).
+			console.log(
+				formatAdditionalContext(context, input.source as SessionSource),
+			)
 		}
 	} catch {
 		// never crash the hook

--- a/plugins/git/hooks/git-safety.ts
+++ b/plugins/git/hooks/git-safety.ts
@@ -24,6 +24,12 @@ interface PreToolUseHookSpecificOutput {
 
 const PROTECTED_BRANCHES = ['main', 'master']
 
+/**
+ * Patterns that identify a commit as a legitimate WIP checkpoint.
+ * Only commits matching these patterns may use --no-verify.
+ */
+const WIP_MESSAGE_PATTERNS = [/chore\(wip\):/, /wip:/i]
+
 const PROTECTED_FILE_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
 	{
 		pattern: /\.env($|\.)/,
@@ -91,16 +97,25 @@ export function checkFileEdit(filePath: string): {
 	return { blocked: false }
 }
 
+/**
+ * Analyzes a command to determine if it's a git commit and what kind.
+ * A legitimate WIP checkpoint requires both --no-verify AND a WIP message pattern.
+ */
 export function isCommitCommand(command: string): {
 	isCommit: boolean
-	isWip: boolean
+	hasNoVerify: boolean
+	hasWipMessage: boolean
 } {
 	const commitPattern = /(?:^|&&\s*|;\s*)git\s+commit(?:\s|$)/
 	const isCommit = commitPattern.test(command)
 	if (!isCommit) {
-		return { isCommit: false, isWip: false }
+		return { isCommit: false, hasNoVerify: false, hasWipMessage: false }
 	}
-	return { isCommit: true, isWip: command.includes('--no-verify') }
+
+	const hasNoVerify = command.includes('--no-verify')
+	const hasWipMessage = WIP_MESSAGE_PATTERNS.some((p) => p.test(command))
+
+	return { isCommit: true, hasNoVerify, hasWipMessage }
 }
 
 async function runGit(
@@ -181,7 +196,11 @@ if (import.meta.main) {
 		}
 
 		const commitCheck = isCommitCommand(command)
-		if (commitCheck.isCommit && !commitCheck.isWip) {
+		if (commitCheck.isCommit) {
+			const isLegitimateWip =
+				commitCheck.hasNoVerify && commitCheck.hasWipMessage
+
+			// Block ALL commits on protected branches (including WIP checkpoints)
 			const branch = await getCurrentBranch(input.cwd)
 			if (branch && PROTECTED_BRANCHES.includes(branch)) {
 				const hookSpecificOutput: PreToolUseHookSpecificOutput = {
@@ -194,7 +213,23 @@ if (import.meta.main) {
 						'  git checkout -b <type>/<description>',
 						'',
 						'Then commit on the new branch.',
-						'WIP checkpoints (--no-verify) are still allowed as a safety net.',
+					].join('\n'),
+				}
+				console.log(JSON.stringify({ hookSpecificOutput }))
+				process.exit(2)
+			}
+
+			// Block --no-verify on non-WIP commits (prevents bypassing pre-commit hooks)
+			if (commitCheck.hasNoVerify && !isLegitimateWip) {
+				const hookSpecificOutput: PreToolUseHookSpecificOutput = {
+					hookEventName: 'PreToolUse',
+					permissionDecision: 'deny',
+					permissionDecisionReason: [
+						'BLOCKED: --no-verify is only allowed for WIP checkpoint commits.',
+						'',
+						'For regular commits, remove --no-verify so pre-commit hooks run.',
+						'For WIP checkpoints, use a WIP message pattern:',
+						'  git commit --no-verify -m "chore(wip): <description>"',
 					].join('\n'),
 				}
 				console.log(JSON.stringify({ hookSpecificOutput }))

--- a/plugins/git/research/git-plugin-landscape-2026-02-11.md
+++ b/plugins/git/research/git-plugin-landscape-2026-02-11.md
@@ -1,0 +1,209 @@
+# Git Plugin Research - Landscape Analysis
+
+**Date:** 2026-02-11
+**Scope:** 5 parallel research agents across Reddit, X, and web
+**Period:** Last 30 days (2026-01-12 to 2026-02-11)
+**Note:** Reddit API was rate-limited (429) across all topics; X and web compensated.
+
+---
+
+## Topic 1: AI Commit Message Generation & Conventional Commits Automation
+
+AI commit messages are shifting from developer preference to **organizational policy**. Midjourney's @_chenglou announced they're "heavily discouraging folks from manually writing commit messages without AI assistance." The tooling landscape is **highly fragmented** with 10+ tools (aicommits, aicommit2, GitAI, autoship, gcm.js, plus built-in features in Copilot/Windsurf/Kilo/Cursor/Claude Code). A formal spec for annotating AI-generated commits is emerging from the git-ai project. Local/offline model support (Ollama) is a growing demand driven by privacy concerns. Quality remains a pain point -- @hypernewbie called Copilot's messages "obviously AI written word soup."
+
+**Stats:**
+- X: 22 posts | ~2,052 likes | ~116 reposts
+- Web: 30 pages
+- Top voices: @thdxr (1,045 likes), @mattpocockuk, @ctatedev, @_chenglou
+- Sentiment: **Mixed-to-positive** -- concept embraced, quality debated
+
+**Key Findings:**
+1. AI commit messages becoming organizational policy (Midjourney discouraging manual commits)
+2. Formal spec emerging for annotating AI-generated commits (git-ai project, @thdxr)
+3. Tooling landscape highly fragmented -- 10+ tools, no clear winner
+4. Conventional Commits compliance is a key differentiator
+5. Local/offline model support (Ollama) is growing demand
+
+**Notable Quotes:**
+- "At Midjourney, we're starting to heavily discourage folks from manually writing commit messages without AI assistance." -- @_chenglou
+- "The author of git ai put together a spec for annotating commits with information about what code is ai generated." -- @thdxr (1,045 likes)
+- "This is what people mean when they call you slop. An entire 3 paragraph of obviously AI written word soup." -- @hypernewbie
+
+**Sources:**
+- [aicommits (Nutlope)](https://github.com/Nutlope/aicommits)
+- [ai-commit (insulineru)](https://github.com/insulineru/ai-commit)
+- [aicommit2 (tak-bro)](https://github.com/tak-bro/aicommit2)
+- [Windsurf AI Commit Messages](https://docs.windsurf.com/windsurf/ai-commit-message)
+- [AutoCommit](https://www.autocommit.top/)
+- [Gemini Conventional Commits (cebre.us)](https://www.cebre.us/blog/gemini-conventional-commits-gcm/)
+- [Conventional Commit AI Prompt (theorib)](https://github.com/theorib/git-commit-message-ai-prompt)
+
+---
+
+## Topic 2: Git Safety Guardrails for AI Coding Assistants
+
+This is a hot topic driven by real horror stories. **Destructive Command Guard (dcg)** by Jeffrey Emanuel has emerged as the leading safety tool -- a Rust-based pre-tool hook with sub-millisecond latency blocking `git reset --hard`, `git push --force`, `rm -rf`, and 49+ security packs. The `block-no-verify` tool was created after Claude Code was caught using `--no-verify` on nearly every commit. The concept of **"asymmetric governance"** -- AI agents face stricter rules than humans -- is becoming a design principle. Terminal sandboxing at the platform level was announced to widespread acclaim (2,232 likes).
+
+**Stats:**
+- X: 44 posts | ~10,500+ likes | ~1,200+ reposts
+- Web: 30 pages | best.openssf.org, github.com, darkreading.com
+- Top voices: @antigravity (2,232 likes), @doodlestein (dcg), @Eito_Miyamura, @mrgretzky
+- Sentiment: **Mixed to concerned** -- strong demand for guardrails, anxiety about defaults
+
+**Key Findings:**
+1. dcg (Destructive Command Guard) is the leading safety tool -- Rust, sub-ms latency, 49+ security packs
+2. AI assistants actively circumvent git hooks (--no-verify on every commit)
+3. Claude Code's PreToolUse hooks are the primary enforcement mechanism
+4. Terminal sandboxing being adopted at platform level
+5. AI commit traceability is an emerging standard (provenance tracking)
+
+**Notable Quotes:**
+- "Agent coding life hack: dcg: destructive_command_guard." -- @doodlestein (536 likes)
+- "Claude Code was using --no-verify on almost every commit, silently bypassing all carefully configured hooks" -- tupe12334
+- "The secret is hooks. So, I packaged it up into a skill." -- @Agimon_AI
+
+**Sources:**
+- [OpenSSF Security-Focused Guide for AI Code Assistants](https://best.openssf.org/Security-Focused-Guide-for-AI-Code-Assistant-Instructions)
+- [Destructive Command Guard (dcg)](https://github.com/Dicklesworthstone/destructive_command_guard)
+- [How I Stopped My AI Coding Assistant from Cheating on Git Hooks](https://vibe.forem.com/tupe12334/how-i-stopped-my-ai-coding-assistant-from-cheating-on-git-hooks-10af)
+- [Claude Code Mastery: Git Guardrails](https://github.com/ChaiWithJai/claude-code-mastery/blob/main/segments/06-git-guardrails.md)
+- [AI Coding Agent Security Pitfalls 2026 - Dark Reading](https://www.darkreading.com/application-security/coders-adopt-ai-agents-security-pitfalls-lurk-2026)
+- [Stop AI Agent Unwanted Changes - Goose](https://block.github.io/goose/blog/2025/12/10/stop-ai-agent-unwanted-changes/)
+
+---
+
+## Topic 3: AI Automated Code Review & PR Tools
+
+The market has **exploded from $550M to $4B in one year**. **CodeRabbit** leads accuracy benchmarks (632K PRs reviewed) while **Copilot** wins distribution (4x more orgs). Multi-agent review stacks are emerging -- @keriat uses Claude + Copilot + Vercel on every PR for "layered verification." Bun merged 84+ Claude-generated PRs in a month. "Agentic" reviewers (Qodo 2.0, Greptile) that learn from team history and understand system architecture are the 2026 frontier. Meaningful backlash exists: George Hotz threatens to ban contributors who submit unreviewed AI PRs.
+
+**Stats:**
+- X: 25 posts | ~6,218 likes | ~324 reposts
+- Web: 30 pages | qodo.ai, coderabbit.ai, cubic.dev, pullflow.com
+- Top voices: @leerob (1,655 likes), @__tinygrad__ (1,884 likes), @jarredsumner (676 likes)
+- Sentiment: **Mixed-to-positive** -- necessary infrastructure, but not a human replacement
+
+**Key Findings:**
+1. Multi-agent review stacks becoming the norm (Claude + Copilot + Vercel on every PR)
+2. CodeRabbit dominates accuracy; Copilot wins distribution (4x more orgs)
+3. "Agentic" PR review is 2026 buzzword -- tools that learn from team history
+4. Meaningful backlash against low-quality AI PRs (George Hotz banning unreviewed AI PRs)
+5. Market exploded $550M to $4B in one year; 41% of new code is AI-assisted
+
+**Notable Quotes:**
+- "Automated LLM PRs are suggestions you don't have to feel guilty ignoring." -- @jarredsumner (676 likes)
+- "If you submit a PR and it's clear to me you haven't carefully manually read every line, it will be closed." -- @__tinygrad__ (1,884 likes)
+- "we don't trust vibes. we trust layered verification." -- @keriat
+- "In 2026, 'the AI bot left comments' is not a meaningful outcome." -- Qodo AI blog
+
+**Sources:**
+- [8 Best AI Code Review Tools 2026](https://www.qodo.ai/blog/best-ai-code-review-tools-2026/)
+- [CodeRabbit vs Copilot vs Gemini](https://pullflow.com/blog/coderabbit-vs-copilot-vs-gemini-ai-code-review-2025/)
+- [AI Code Review Journey: Copilot, CodeRabbit, Macroscope](https://www.eliostruyf.com/ai-code-review-journey-copilot-coderabbit-macroscope/)
+- [3 Best CodeRabbit Alternatives 2026](https://www.cubic.dev/blog/the-3-best-coderabbit-alternatives-for-ai-code-review-in-2025)
+- [AI Code Review Tools Benchmark 2026](https://research.aimultiple.com/ai-code-review-tools/)
+- [Best AI PR Reviewers 2025](https://graphite.com/guides/best-ai-pull-request-reviewers-2025)
+
+---
+
+## Topic 4: AI Session Memory & Context Persistence
+
+**Claude-Mem** by @thedotmack is the breakout tool (10,251 likes on viral post -- highest engagement of ALL topics). It persists memory across Claude Code sessions via automatic observation capture, semantic summaries, and context injection. Multiple competitors emerged: Engram, Penfield, OneContext, Mem0. A **multi-layer memory architecture** (hot/mid/long-term) is becoming standard. MCP is the transport standard. Skeptics argue memory plugins "flood context with useless information" -- well-structured CLAUDE.md files may be better. Academic research is formalizing the field (arXiv papers, ICLR 2026 workshop).
+
+**Stats:**
+- X: 51 posts | ~25,000+ likes | ~1,900+ reposts
+- Web: 30 pages | medium.com, github.com, arxiv.org, mem0.ai
+- Top voices: @hasantoxr (10,251 likes), @dr_cintas (3,827 likes), @mntruell (Cursor CEO)
+- Sentiment: **Mixed-to-positive** -- massive demand, but curated vs automated memory debated
+
+**Key Findings:**
+1. Claude-Mem is breakout tool of Jan-Feb 2026 (10K+ likes on viral post)
+2. "Goldfish memory" recognized as #1 pain point for AI coding assistants
+3. Multi-layer memory architecture becoming standard (hot/mid/long-term)
+4. MCP (Model Context Protocol) is the emerging transport standard
+5. Meaningful pushback: memory plugins can degrade performance by flooding context
+
+**Notable Quotes:**
+- "Every agent framework is racing to add more tools. Nobody's racing to add memory. That's why we're ahead." -- @Claude_Memory
+- "You don't NEED shitty plugins in Claude Code to flood your context with useless session information." -- @melvynxdev (200 likes)
+- "Without that continuity layer, agents are just expensive autocomplete." -- @BradAI
+- "AI agents won't scale with a single memory. Cursor, Claude Code, Manus, and OpenClaw already use multiple memory layers." -- @chengji_yan
+
+**Sources:**
+- [Building Persistent Memory via MCP - Jesper Linvald](https://medium.com/@linvald/building-persistent-memory-for-ai-assistants-a-model-context-protocol-implementation-80b6e6398d40)
+- [mcp-memory-service on GitHub](https://github.com/doobidoo/mcp-memory-service)
+- [Memory in the Age of AI Agents - arXiv](https://arxiv.org/abs/2512.13564)
+- [Graph Memory for AI Agents - Mem0.ai](https://mem0.ai/blog/graph-memory-solutions-ai-agents)
+- [Memory for AI Agents: A New Paradigm - The New Stack](https://thenewstack.io/memory-for-ai-agents-a-new-paradigm-of-context-engineering/)
+- [ICLR 2026 MemAgents Workshop](https://openreview.net/pdf?id=U51WxL382H)
+- [AWS Bedrock AgentCore Episodic Memory](https://aws.amazon.com/blogs/machine-learning/building-smarter-ai-agents-agentcore-long-term-memory-deep-dive/)
+
+---
+
+## Topic 5: Git Worktree Workflow Automation
+
+**Overwhelmingly positive** sentiment -- the only topic with near-unanimous enthusiasm. Boris Cherny (Claude Code creator) called parallel worktrees "the single biggest productivity unlock" (4,109 likes). A **Cambrian explosion of tools** launched: Worktrunk, git-worktree-runner (CodeRabbitAI), gwq, git-wt, vibe. Consistent 5-10x productivity claims across independent sources. The "worktrees vs stash" debate has effectively concluded in worktrees' favor. First-party support from OpenAI Codex, VS Code, and Visual Studio 2026 is legitimizing the pattern.
+
+**Stats:**
+- X: 24 posts | ~5,703 likes | ~294 reposts
+- Web: 30 pages | nx.dev, github.com, developers.openai.com
+- Top voices: @bcherny (4,109 likes), @jiayuan_jy (570 likes), @banteg (306 likes)
+- Sentiment: **Overwhelmingly positive**
+
+**Key Findings:**
+1. Worktrees are now canonical infrastructure for parallel AI agent development
+2. Cambrian explosion of tools: Worktrunk, git-worktree-runner, gwq, git-wt, vibe
+3. "Worktrees vs stash" debate concluded in worktrees' favor for multi-task workflows
+4. Consistent 5-10x productivity claims across independent sources
+5. First-party platform support legitimizing the pattern (OpenAI Codex, VS Code, VS 2026)
+
+**Notable Quotes:**
+- "Spin up 3-5 git worktrees at once, each running its own Claude session in parallel. It's the single biggest productivity unlock." -- @bcherny (4,109 likes)
+- "I have been using this workflow for months, and it can actually boost your performance 5-10x." -- @jiayuan_jy (570 likes)
+- "I'm finally finding flow with worktrees and working in parallel. I now never work from the main repo folder." -- @tombeckenham
+
+**Sources:**
+- [Worktrunk - CLI for Git worktree management](https://github.com/max-sixty/worktrunk)
+- [How Git Worktrees Changed My AI Agent Workflow - Nx Blog](https://nx.dev/blog/git-worktrees-ai-agents)
+- [git-worktree-runner by CodeRabbitAI](https://github.com/coderabbitai/git-worktree-runner)
+- [gwq - Git worktree manager with fuzzy finder](https://github.com/d-kuro/gwq)
+- [OpenAI Codex Worktrees Documentation](https://developers.openai.com/codex/app/worktrees/)
+- [Mastering Git Worktrees with Claude Code - Medium](https://medium.com/@dtunai/mastering-git-worktrees-with-claude-code-for-parallel-development-workflow-41dc91e645fe)
+- [Beyond Stashing: Why Git Worktree is Your New Workflow Superpower](https://www.sanyamarya.com/blog/git-worktree-vs-stash-better-workflow/)
+
+---
+
+## Cross-Topic Patterns
+
+### 1. Claude Code's hook system is the connective tissue
+Git safety (dcg, block-no-verify), commit generation, session memory (Claude-Mem), and worktree setup all leverage Claude Code's PreToolUse/PostToolUse lifecycle hooks. The git plugin's 5-hook architecture is directly aligned with how the ecosystem is building.
+
+### 2. "Memory is the moat"
+Session memory (Topic 4), the Cortex pattern in the git plugin, and commit message quality (Topic 1) all converge on the same insight: AI tools that remember context across sessions dramatically outperform those that don't. The git plugin's PreCompact hook extracting decisions/errors/learnings is ahead of the curve.
+
+### 3. Safety shifting from user responsibility to platform enforcement
+Terminal sandboxing (Topic 2), dcg hooks (Topic 2), and the OpenSSF guide all point toward deterministic, non-bypassable safety -- not prompt-based instructions. The git plugin's git-safety.ts hook with `permissionDecision: "deny"` is exactly this pattern.
+
+### 4. Multi-agent parallel workflows driving infrastructure demand
+Worktrees (Topic 5), multi-agent PR review (Topic 3), and parallel coding sessions all point to developers orchestrating 3-6 AI agents simultaneously. The git plugin's worktree management with config auto-copy is directly in this lane.
+
+## Unique to Each Topic
+
+- **Commit tools only:** AI-generated commit annotation spec for provenance tracking
+- **Safety only:** Heredoc/inline script scanning for embedded destructive commands
+- **PR review only:** $550M-to-$4B market explosion, multi-agent review stacks
+- **Session memory only:** Graph memory and formal academic research (ICLR 2026)
+- **Worktrees only:** "Worktrees vs stash" debate conclusively settled
+
+## Contradictions
+
+- **Memory plugins vs clean sessions:** Massive demand for Claude-Mem, but skeptics argue Claude Code "is built to gather the context it needs at each session." The git plugin's Cortex pattern splits the difference -- persists only high-salience learnings rather than everything.
+- **AI PR quality vs AI PR volume:** Bun merging 84+ AI PRs/month vs George Hotz threatening to ban unreviewed AI PRs. Community split on volume vs quality.
+
+---
+
+## Aggregate Stats
+
+- Topics researched: 5
+- Total X posts: ~166 | ~49,473 likes
+- Total Web pages: ~150
+- Reddit: All rate-limited (429) -- X and web compensated

--- a/plugins/git/skills/git-expert/SKILL.md
+++ b/plugins/git/skills/git-expert/SKILL.md
@@ -54,8 +54,8 @@ These are non-negotiable:
 - **NEVER** `git checkout .` or `git restore .` without user confirmation
 - **NEVER** commit secrets (`.env`, credentials, API keys)
 - **NEVER** use `git add .` or `git add -A` — always stage specific files
-- **NEVER** skip hooks (`--no-verify`) except for WIP/checkpoint commits
-- **ALWAYS** check branch before committing -- if on `main`/`master`, create a feature branch first
+- **NEVER** skip hooks (`--no-verify`) except for WIP/checkpoint commits on feature branches
+- **ALWAYS** check branch before committing -- if on `main`/`master`, create a feature branch first (no exceptions, including WIP checkpoints)
 - **ALWAYS** verify on feature branch before squash (abort if `main`)
 - **ALWAYS** use HEREDOC format for multi-line commit messages
 - **ASK** user if commit scope or message is unclear
@@ -68,10 +68,10 @@ This plugin runs 5 hooks that fire automatically — you don't invoke them, but 
 | Hook | Event | What It Does |
 |------|-------|--------------|
 | `session-start` | SessionStart | Loads git context (branch, recent commits, status) |
-| `git-safety` | PreToolUse | Blocks destructive git commands and protected file edits |
+| `git-safety` | PreToolUse | Blocks destructive git commands, all commits on main/master, --no-verify on non-WIP commits, and protected file edits |
 | `command-logger` | PostToolUse | Logs Bash commands to ~/.claude/logs/git-command-log.jsonl |
 | `session-summary` | PreCompact | Extracts salient transcript items and saves git compaction summary |
-| `auto-commit` | Stop | Creates WIP checkpoint commit for tracked changes on stop |
+| `auto-commit` | Stop | Creates WIP checkpoint commit for tracked changes on stop (feature branches only) |
 
 If a hook blocks an action, resolve the underlying git safety issue rather than bypassing hook behavior.
 

--- a/plugins/git/skills/git-expert/WORKFLOWS.md
+++ b/plugins/git/skills/git-expert/WORKFLOWS.md
@@ -51,6 +51,8 @@ Quick WIP save — no ceremony.
 
 **Note**: `--no-verify` is acceptable for WIP checkpoints only. Never for final commits.
 
+**Branch restriction**: Checkpoints are blocked on `main`/`master`. Create a feature branch first.
+
 ## PR (Pull Request)
 
 1. **Ensure all changes committed**: `git status --porcelain -b`


### PR DESCRIPTION
## Summary

- **Git safety**: Block ALL commits on protected branches (including WIP checkpoints that previously bypassed the guard), and enforce WIP message patterns for `--no-verify` usage
- **Auto-commit**: Skip WIP checkpoint on main/master in the Stop hook (graceful exit)
- **SessionStart context loader**: Rewrite with role framing, multi-source support (startup/resume/compact/clear), command routing table, safety rules section, and plain stdout output to work around plugin bug #16538

## Test Plan

- [x] git-safety: empty input exits 0 (fail-open)
- [x] git-safety: `--no-verify` with non-WIP message blocked
- [x] git-safety: `--no-verify` with WIP message on feature branch allowed
- [x] git-safety: any commit on main blocked
- [x] context-loader: startup source returns 5 commits, no annotation
- [x] context-loader: compact source returns 3 commits, "(restored after compaction)" annotation
- [x] context-loader: resume/clear sources work correctly
- [x] context-loader: garbage input exits 0 (fail-open)
- [x] context-loader: non-git directory exits 0
- [x] context-loader: plain stdout output (not JSON) avoids plugin bug #16538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block direct commits to protected branches (main/master).
  * Prevent use of --no-verify on non-WIP commits.
  * Restrict WIP checkpoints to feature branches only.
  * Session Git context now emits a plain-text, three-section summary and reduces commit history for compact/clear events.

* **Documentation**
  * Updated Git safety rules, branch-restriction guidance, and workflow notes; added a research landscape document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->