### PR TITLE
fix(research): replace ! preprocessor with explicit Bash in last-30-days skill

### DIFF
--- a/plugins/research/skills/last-30-days/SKILL.md
+++ b/plugins/research/skills/last-30-days/SKILL.md
@@ -85,17 +85,25 @@ echo "Edit to add your API keys for enhanced research."
 
 ## Research Execution
 
-The CLI tool runs automatically below via the `!` preprocessor. Its output is injected directly -- you do NOT need to run Bash yourself.
+**You MUST run the CLI command below via Bash BEFORE doing any WebSearch.** This is step 1 of research -- do not skip it.
 
-### CLI Research Output
+### Step 1: Run CLI Research
 
-!`bunx --bun @side-quest/last-30-days "$ARGUMENTS" --emit=compact 2>&1`
+Run this command using the Bash tool:
 
-### Check the output mode
+```bash
+bunx --bun @side-quest/last-30-days "$ARGUMENTS" --emit=compact 2>&1
+```
 
-The CLI output above will indicate the mode:
+- **If the command succeeds**, it will print research results with a mode line. Save the output and continue to Step 2.
+- **If the command fails or times out**, note the error and continue to Step 2 -- WebSearch will compensate.
+
+### Step 2: Check the output mode
+
+The CLI output will indicate the mode:
 - **"Mode: both"** or **"Mode: reddit-only"** or **"Mode: x-only"**: CLI found results, WebSearch is supplementary
 - **"Mode: web-only"**: No API keys, Claude must do ALL research via WebSearch
+- **No output / error**: CLI failed, treat as web-only mode
 
 ### Supplement with WebSearch
 


### PR DESCRIPTION
## Summary

- Replace the `!` backtick preprocessor with explicit Bash tool instructions in the last-30-days skill
- The preprocessor was silently failing, causing agents to skip CLI data and go straight to WebSearch -- losing all Reddit/X engagement signals
- Adds step numbering, imperative language ("MUST", "BEFORE"), and an error recovery path to match the pattern used by sibling research skills (ai-trends-digest, community-intel)

Fixes #55

## Test plan

- [ ] Run `/research:last-30-days "any topic" --quick` and confirm the agent calls Bash FIRST with the `bunx` command
- [ ] Confirm WebSearch calls follow after CLI output
- [ ] Confirm synthesis includes Reddit/X data with engagement metrics (when API keys are configured)
- [ ] Confirm graceful fallback to web-only mode if CLI fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated research execution guide with explicit step-by-step CLI commands and instructions for improved clarity and user control.
  * Expanded output-mode handling documentation with enhanced guidance for WebSearch functionality across all modes.
  * Improved formatting with code blocks and clarified query-generation rules for different query types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->