### PR TITLE
refactor(chrome-devtools): uplift skill and rename to guide

### DIFF
--- a/plugins/chrome-devtools/.claude-plugin/plugin.json
+++ b/plugins/chrome-devtools/.claude-plugin/plugin.json
@@ -18,5 +18,5 @@
 		"./commands/screenshot.md",
 		"./commands/fix.md"
 	],
-	"skills": ["./skills/chrome-devtools-guide"]
+	"skills": ["./skills/guide"]
 }

--- a/plugins/chrome-devtools/README.md
+++ b/plugins/chrome-devtools/README.md
@@ -16,7 +16,7 @@ Chrome DevTools MCP must be configured at the user level (not in this plugin). T
 
 ## Skill
 
-The `chrome-devtools` skill provides the core automation engine. It handles connection checks, workflow routing, auth detection, secret safety, and graceful degradation. Reference docs are loaded lazily based on the workflow type.
+The `guide` skill provides the core automation engine. It handles connection checks, workflow routing, auth detection, secret safety, and graceful degradation. Reference docs are loaded lazily based on the workflow type.
 
 ## Examples
 

--- a/plugins/chrome-devtools/commands/automate.md
+++ b/plugins/chrome-devtools/commands/automate.md
@@ -3,7 +3,7 @@ description: Automate browser tasks via Chrome DevTools MCP
 argument-hint: "[workflow or description]"
 ---
 
-Invoke the **chrome-devtools-guide** skill to handle this browser automation request.
+Invoke the **guide** skill to handle this browser automation request.
 
 **Arguments received**: `$ARGUMENTS`
 

--- a/plugins/chrome-devtools/commands/fix.md
+++ b/plugins/chrome-devtools/commands/fix.md
@@ -20,11 +20,11 @@ Diagnose and optionally fix Chrome DevTools MCP connection issues.
 
 ## Diagnostic Flow
 
-Run the layered diagnostics from the chrome-devtools-guide skill:
+Run the layered diagnostics from the guide skill:
 
 **Layer 1: MCP probe** -- Call `list_pages` via Chrome DevTools MCP.
 - Success -> Report "Connection healthy. {N} pages open." and stop.
-- Tool not available (not in tool list) -> Report: "Chrome DevTools MCP tools are not registered in this session. Run `/mcp` and reconnect `chrome-devtools`, or run `/mcp-manager:enable chrome-devtools`." In `--check` mode, stop here. In interactive mode, offer to guide the user through reconnection.
+- Tool not available (not in tool list) -> Report: "Chrome DevTools MCP tools are not registered in this session. Run `/doctor` to diagnose MCP connectivity." In `--check` mode, stop here. In interactive mode, offer to guide the user through reconnection.
 - Tool available but returns error -> Continue to Layer 2.
 
 **Layer 2: Port check**
@@ -50,7 +50,7 @@ ps aux | grep -c '[c]hrome-devtools-mcp'
 
 ## After Diagnosis
 
-Load [diagnostics.md](../skills/chrome-devtools-guide/references/diagnostics.md) for the scenario table and fix options.
+Load [diagnostics.md](../skills/guide/references/diagnostics.md) for the scenario table and fix options.
 
 **If `--check` mode**: Report the diagnosis and stop. Do not take any action.
 

--- a/plugins/chrome-devtools/commands/screenshot.md
+++ b/plugins/chrome-devtools/commands/screenshot.md
@@ -9,7 +9,7 @@ Take a screenshot using Chrome DevTools MCP.
 
 ## Steps
 
-1. Run the connection check from the chrome-devtools-guide skill (Layer 1: `list_pages`). On failure, point to `/chrome-devtools:fix`.
+1. Run the connection check from the guide skill (Layer 1: `list_pages`). On failure, point to `/chrome-devtools:fix`.
 2. Parse arguments:
    - **URL** (required) -- the page to screenshot
    - **--full-page** (optional) -- capture the full scrollable page

--- a/plugins/chrome-devtools/skills/guide/SKILL.md
+++ b/plugins/chrome-devtools/skills/guide/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: guide
+description: >
+  Uses Chrome DevTools via MCP for browser automation, debugging, and testing.
+  Use when: automating browser interactions, taking screenshots, testing webapps,
+  analyzing Chrome performance traces, inspecting network requests, validating
+  accessibility, creating npm tokens via browser, setting up GitHub OIDC,
+  debugging web apps, checking page speed, auditing website accessibility,
+  or any task requiring Chrome DevTools.
+argument-hint: "[workflow or URL]"
+allowed-tools:
+  - Bash(lsof *)
+  - Bash(curl *)
+  - Bash(ps *)
+  - Bash(op *)
+  - Bash(gh *)
+  - Bash(kill *)
+  - Bash(rm -f *SingletonLock*)
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - ToolSearch
+  - mcp__chrome-devtools__*
+---
+
+# Chrome DevTools Expert
+
+You are a browser automation expert using the Chrome DevTools MCP. Before any workflow, always verify the connection is healthy.
+
+## 1. Connection Check (Always First)
+
+Call `list_pages` via the Chrome DevTools MCP before any workflow.
+- **Success** -> proceed with the workflow
+- **Tool not available** -> MCP not registered. Tell user to run `/doctor` to diagnose MCP connectivity. STOP.
+- **Tool returns error** -> run the full 4-layer diagnostic from [diagnostics.md](references/diagnostics.md)
+
+**On failure**: Report the specific diagnosis and tell the user to run `/chrome-devtools:fix`. Never silently proceed without a connection.
+
+## 2. Core Concepts
+
+- **Browser auto-starts** on first MCP tool call with a persistent user profile
+- **Page selection**: `list_pages` -> `select_page` by URL or title
+- **Element interaction**: `take_snapshot` for accessibility UIDs, then `click`/`fill` by UID
+- **Large outputs**: Use `filePath` param to write results to disk instead of stdout
+- **Screenshot files**: NEVER use the `Read` tool to display screenshot images saved to disk. Report the file path to the user instead. Full-page captures can exceed API size limits and crash the conversation.
+- **Pagination**: Use `pageIdx`/`pageSize` for list tools with many entries
+
+## 3. Recommended Setup
+
+Five connection modes, each with different trade-offs:
+
+| Mode | Best For | Trade-off |
+|------|----------|-----------|
+| Default (auto-launch) | Quick tasks, clean state | Separate profile, no existing auth |
+| `--browserUrl` (recommended for existing Chrome) | Daily driver, persistent sessions | Manual Chrome launch required |
+| `--autoConnect` (Chrome 144+) | Auth-gated sites, debugging handoff | Permission dialog every connection, bug-prone |
+| `--wsEndpoint` | Remote/sandboxed browsers, auth endpoints | Requires WebSocket URL |
+| `--isolated` | Clean-slate testing, CI | Loses all state between sessions |
+
+- **Default** is zero-config -- the MCP launches Chrome automatically with a persistent profile. Best for one-off automation and testing.
+- **`--browserUrl`** is the most reliable method for connecting to an existing browser. Launch Chrome yourself with `--remote-debugging-port=9222` and `--user-data-dir` and point the MCP at it. No permission dialogs, works with any Chrome version. Best for daily development workflows.
+- **`--autoConnect`** connects to your already-running Chrome via Chrome 144+'s native DevTools endpoint. Best when you need existing cookies/sessions (e.g., authenticated sites). Shows a permission dialog on each connection and has known issues with frozen tabs and profile conflicts.
+- **`--wsEndpoint`** connects via a WebSocket URL, useful for remote browsers (Docker, Browserless) or authenticated endpoints. Pair with `--wsHeaders` for auth tokens.
+- **`--isolated`** uses a temporary profile directory, preventing profile locks but losing all session state. Best for CI or clean-state testing.
+
+See [diagnostics.md](references/diagnostics.md) for setup details, known issues, and a complete server flags reference.
+
+## 4. Workflow Routing
+
+Match the user's intent and load the appropriate reference:
+
+| Intent | Reference | Key Pattern |
+|--------|-----------|-------------|
+| Performance audit | [browser-workflows.md](references/browser-workflows.md) | trace -> analyze insights |
+| Network monitoring | [browser-workflows.md](references/browser-workflows.md) | list_network_requests -> filter |
+| Accessibility testing | [browser-workflows.md](references/browser-workflows.md) | snapshot verbose -> validate |
+| Browser automation | [browser-workflows.md](references/browser-workflows.md) | snapshot -> UIDs -> interact |
+| Multi-tab management | [browser-workflows.md](references/browser-workflows.md) | list -> new -> select |
+| Device emulation | [browser-workflows.md](references/browser-workflows.md) | emulate viewport + network |
+| npm token creation | [publishing-workflows.md](references/publishing-workflows.md) | Auth, form fill, 1Password |
+| OIDC setup | [publishing-workflows.md](references/publishing-workflows.md) | Auth, form fill |
+| GitHub secret/protection | [publishing-workflows.md](references/publishing-workflows.md) | Prefer `gh` CLI |
+| Console debugging | [debugging-workflows.md](references/debugging-workflows.md) | console messages -> evaluate -> fix |
+| Network debugging | [debugging-workflows.md](references/debugging-workflows.md) | list requests -> filter -> diagnose |
+| Debug-fix loop | [debugging-workflows.md](references/debugging-workflows.md) | reproduce -> analyze -> fix -> verify |
+| Screenshot | Direct (no ref needed) | navigate -> wait -> take_screenshot |
+| Custom automation | Direct | navigate -> snapshot -> interact |
+| Connection issues | [diagnostics.md](references/diagnostics.md) | Layered diagnostic flow |
+| Tool parameters | [tools.md](references/tools.md) | High-signal tool reference |
+
+## 5. Core Patterns
+
+### Snapshot-First Element Finding
+
+Always `take_snapshot` before interacting with elements:
+- Match by **accessible name** (visible text) and **role** (button, textbox, link)
+- If not found, re-snapshot and try alternative labels (e.g., "Generate token" vs "Create token")
+- Only use `take_screenshot` for visual verification, never for element discovery
+
+### Auth Detection
+
+Before any site workflow, check login state via snapshot. See [publishing-workflows.md](references/publishing-workflows.md) "Auth Detection" for the full pattern. If not logged in, tell the user to log in manually, then `wait_for` authenticated state.
+
+### 1Password Secret Storage
+
+When workflows create secrets, offer to store them via `op` CLI. See [publishing-workflows.md](references/publishing-workflows.md) "1Password Vault Storage" for vault name, auth setup, commands, and graceful degradation.
+
+### Secret Safety
+
+**CRITICAL**: NEVER call `take_screenshot` after a secret or token is revealed on screen. The token would be persisted as an image file.
+- Screenshot BEFORE the generate/reveal step for verification
+- After reveal, use `take_snapshot` (text only) to extract the value
+- Display only first 8 characters to the user: `npm_1234abcd...`
+- Immediately offer storage (1Password -> gh secret set -> manual copy)
+
+## 6. Token Efficiency
+
+Minimize token usage and context window pressure:
+
+- **Prefer `take_snapshot` over `take_screenshot`** -- snapshots are 2-5KB of structured text vs 100KB+ for screenshots. Use snapshots for element discovery and state checking; reserve screenshots for visual verification only.
+- **Use `filePath` on any tool that supports it** when output is large. Trace results, HAR exports, and long console logs should go to disk rather than inline. This keeps the conversation context lean.
+- **Batch form fills with `fill_form`** instead of calling `fill` individually on each field. One tool call vs N tool calls for N fields.
+- **Filter `list_network_requests` with `resourceTypes`** -- pass `["xhr", "fetch"]` to isolate API calls instead of dumping hundreds of image/font/stylesheet entries.
+- **Use `pageIdx`/`pageSize` pagination** on list tools (`list_network_requests`, `list_console_messages`) to retrieve only what you need. Start with page 0, small page size, and paginate forward only if needed.
+
+## 7. Graceful Degradation
+
+On any failure mid-workflow:
+1. Screenshot current state (if connection alive AND no secrets visible on screen)
+2. Report which step failed and what is visible
+3. Provide remaining steps as manual click-by-click instructions
+4. Never retry destructive actions automatically

--- a/plugins/chrome-devtools/skills/guide/references/browser-workflows.md
+++ b/plugins/chrome-devtools/skills/guide/references/browser-workflows.md
@@ -1,0 +1,312 @@
+# Browser Workflows
+
+Generic browser automation workflows using Chrome DevTools MCP tools.
+
+---
+
+## Performance Analysis
+
+Capture and analyze Chrome performance traces for Core Web Vitals.
+
+1. `navigate_page` to the target URL
+2. `performance_start_trace` with `reload: true, autoStop: true` -- reloads the page and automatically stops after load completes. Use `reload: false, autoStop: false` if you need to capture interactions after page load (then manually call `performance_stop_trace` when done).
+3. If `autoStop: false`: interact with the page (scroll, click, navigate) to simulate user behavior, then call `performance_stop_trace`
+4. Review the trace results -- they include CWV scores and a list of available insight sets with IDs
+5. `performance_analyze_insight` with `insightSetId` (from the trace results) and `insightName` (e.g., "LCPBreakdown", "DocumentLatency") -- drill into specific insights
+
+**CWV thresholds** (see [tools.md](tools.md) for full reference):
+- INP <= 200ms good, <= 500ms needs improvement
+- LCP <= 2.5s good, <= 4.0s needs improvement
+- CLS <= 0.1 good, <= 0.25 needs improvement
+- TBT < 200ms (lab proxy for INP)
+
+**Tips**:
+- Use `emulate` to throttle CPU/network before tracing for realistic mobile conditions
+- Take a screenshot before and after to visually bookend the trace
+- Use `filePath` param on trace tools if the output is large
+
+---
+
+## Network Monitoring
+
+Capture and analyze network requests during page interactions.
+
+1. `navigate_page` to the target URL
+2. Interact with the page to trigger network activity
+3. `list_network_requests` -- enumerate all captured requests
+4. `get_network_request` -- inspect individual request/response details
+
+**Filtering patterns**:
+- Filter by `resourceTypes` array (e.g., `["xhr", "fetch"]` to isolate API calls)
+- Available types: document, stylesheet, image, media, font, script, xhr, fetch, websocket, and others
+- Use `pageIdx`/`pageSize` for pagination on busy pages
+
+**HAR-style export**: Use `filePath` param to write request data to disk for offline analysis.
+
+---
+
+## Accessibility Testing
+
+Validate page accessibility against WCAG 2.1 AA using the Chrome accessibility tree and JavaScript evaluation.
+
+### Basic Audit
+
+1. `navigate_page` to the target URL
+2. `take_snapshot` -- get the full accessibility tree
+3. Validate ARIA roles, labels, and structure
+4. Check for common issues:
+   - Missing alt text on images (role: img without name)
+   - Buttons/links without accessible names
+   - Form inputs without labels
+   - Heading hierarchy violations (h1 -> h3 skip)
+   - Missing landmark regions (main, nav, footer)
+
+### WCAG 2.1 AA Checklist
+
+Run through these checks systematically using `take_snapshot` and `evaluate_script`:
+
+**Perceivable**:
+- [ ] All images have meaningful alt text (or `alt=""` for decorative)
+- [ ] Video/audio has captions or transcripts
+- [ ] Color is not the sole means of conveying information
+- [ ] Text has sufficient contrast ratio (4.5:1 normal, 3:1 large text)
+- [ ] Page is readable and functional at 200% zoom
+- [ ] Content reflows at 320px width without horizontal scrolling
+
+**Operable**:
+- [ ] All interactive elements are keyboard accessible (Tab, Enter, Space, Escape)
+- [ ] Focus order follows a logical reading sequence
+- [ ] Focus indicators are visible on all interactive elements
+- [ ] No keyboard traps (user can Tab away from every element)
+- [ ] Skip-to-content link exists for bypassing navigation
+- [ ] Page title is descriptive and unique
+
+**Understandable**:
+- [ ] `lang` attribute set on `<html>` element
+- [ ] Form inputs have visible labels (not just placeholders)
+- [ ] Error messages identify the field and describe the problem
+- [ ] Consistent navigation across pages
+
+**Robust**:
+- [ ] Valid HTML (no duplicate IDs, proper nesting)
+- [ ] ARIA roles match element behavior
+- [ ] Custom widgets have appropriate ARIA states (expanded, selected, checked)
+
+### Color Contrast Checking
+
+Use `evaluate_script` to compute contrast ratios for text elements. The `function` param takes an arrow function:
+
+```javascript
+// evaluate_script function param -- check contrast ratio for a specific element
+(selector) => {
+  const el = document.querySelector(selector);
+  const style = window.getComputedStyle(el);
+  const color = style.color;
+  const bg = style.backgroundColor;
+
+  function luminance(r, g, b) {
+    const [rs, gs, bs] = [r, g, b].map(c => {
+      c = c / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+  }
+
+  function parseRGB(str) {
+    const m = str.match(/\d+/g);
+    return m ? m.slice(0, 3).map(Number) : [0, 0, 0];
+  }
+
+  const [r1, g1, b1] = parseRGB(color);
+  const [r2, g2, b2] = parseRGB(bg);
+  const l1 = luminance(r1, g1, b1);
+  const l2 = luminance(r2, g2, b2);
+  const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+
+  return JSON.stringify({
+    foreground: color,
+    background: bg,
+    ratio: ratio.toFixed(2),
+    passesAA_normal: ratio >= 4.5,
+    passesAA_large: ratio >= 3,
+    passesAAA_normal: ratio >= 7
+  });
+}
+// Call with args: ["h1"] or any CSS selector
+```
+
+**Thresholds** (WCAG 2.1 AA):
+- Normal text (< 18pt or < 14pt bold): contrast ratio >= 4.5:1
+- Large text (>= 18pt or >= 14pt bold): contrast ratio >= 3:1
+- UI components and graphical objects: contrast ratio >= 3:1
+
+### Keyboard Navigation Testing
+
+Test that the page is fully operable via keyboard:
+
+1. `navigate_page` to the target URL
+2. Use `press_key` with `Tab` to move through interactive elements
+3. After each Tab press, `take_snapshot` to check which element has focus
+4. Verify:
+   - **Focus order** follows a logical reading sequence (left-to-right, top-to-bottom)
+   - **Focus indicators** are visible (element has a visible outline or highlight)
+   - **No keyboard traps** -- pressing Tab always moves to the next element
+   - **Interactive elements reachable** -- every button, link, and input receives focus
+5. Test activation: `press_key` with `Enter` or `Space` on focused buttons/links
+6. Test dismissal: `press_key` with `Escape` on modals/dropdowns
+
+**Common keyboard failures**:
+- Custom `<div>` or `<span>` buttons without `tabindex="0"` and `role="button"`
+- Modal dialogs that don't trap focus inside or restore focus on close
+- Dropdown menus that can't be navigated with arrow keys
+- Skip-to-content link missing or not functional
+
+### Common ARIA Anti-patterns
+
+Flag these patterns in the accessibility snapshot:
+
+| Anti-pattern | What to look for | Correct approach |
+|-------------|-----------------|------------------|
+| Redundant roles | `<button role="button">` | Omit role -- native elements have implicit roles |
+| Role misuse | `<div role="button">` without keyboard handling | Use native `<button>` instead |
+| Missing live regions | Dynamic content updates without `aria-live` | Add `aria-live="polite"` to container |
+| Placeholder-only labels | `<input placeholder="Email">` with no `<label>` | Add visible `<label>` or `aria-label` |
+| Generic link text | `<a>Click here</a>`, `<a>Read more</a>` | Descriptive text: `<a>Read the accessibility report</a>` |
+| Presentational with children | `role="presentation"` on parent with interactive children | Remove role or restructure |
+| Invalid ARIA attributes | `aria-checked` on non-checkbox elements | Match ARIA states to element role |
+
+### Landmark Region Validation
+
+Check that the page has proper landmark structure via `take_snapshot`:
+
+**Required landmarks**:
+- `main` -- exactly one per page (primary content area)
+- `navigation` -- at least one (site navigation)
+- `banner` -- page header (implicit on `<header>` when direct child of `<body>`)
+- `contentinfo` -- page footer (implicit on `<footer>` when direct child of `<body>`)
+
+**Validation rules**:
+- All page content should be contained within a landmark region
+- Multiple `navigation` landmarks must have unique `aria-label` values
+- `main` landmark must not be nested inside other landmarks
+- `banner` and `contentinfo` should be top-level (not nested)
+
+**Tips**:
+- Use verbose snapshot mode for detailed ARIA properties
+- Compare snapshot against the WCAG 2.1 AA checklist above
+- Screenshot specific elements for visual verification of contrast and focus indicators
+- Run checks on multiple pages -- consistent navigation and landmark structure matters
+
+---
+
+## Browser Automation
+
+General-purpose browser interaction pattern.
+
+### Navigation Pattern
+
+Every automation follows this sequence:
+
+1. `navigate_page` to the target URL
+2. `wait_for` the page to load (check for expected text on the page)
+3. `take_snapshot` to get the accessibility tree
+4. Identify target elements by **text content and role** (never hardcoded coordinates)
+5. Perform action (`click`, `fill`, `press_key`)
+6. `take_screenshot` to verify the result
+
+**Advanced**: Use `navigate_page` with `initScript` to inject JavaScript that runs before any page scripts on the next navigation. Useful for mocking APIs, setting feature flags, or patching globals before the app boots.
+
+### Element Finding: Snapshot-First
+
+**Always use `take_snapshot` to locate elements.** It is cheaper, faster, and more resilient to UI changes than screenshots.
+
+- Match elements by their **accessible name** (visible text) and **role** (button, link, textbox)
+- If the primary text isn't found, search for alternative labels (e.g., "Submit" vs "Save" vs "OK")
+- Only use `take_screenshot` for visual verification after actions, not for element discovery
+- Re-snapshot after any page state change (navigation, form submission, dialog)
+
+### Form Filling
+
+For multi-field forms:
+1. `take_snapshot` to discover all form fields
+2. `fill` each field by UID
+3. For dropdowns: `click` to open, `take_snapshot` to find options, `click` the target option
+4. For checkboxes/radios: `click` the element by UID
+5. `take_snapshot` before submitting to verify all fields are filled
+6. `click` the submit button
+7. `wait_for` success state
+
+---
+
+## Multi-Tab Management
+
+Work with multiple browser tabs simultaneously.
+
+1. `list_pages` -- enumerate all open tabs (returns pageId, URL, title)
+2. `new_page` -- open a new tab (optionally with a URL)
+3. `select_page` -- switch active tab by pageId
+4. `close_page` -- close a specific tab
+
+**Tips**:
+- Always `list_pages` before assuming which tab is active
+- After `select_page`, `take_snapshot` to confirm you're on the right page
+- Use multi-tab for workflows that need to compare two pages side-by-side
+
+---
+
+## Device Emulation
+
+Test responsive designs and mobile experiences.
+
+1. `emulate` -- set device viewport, user agent, network conditions, and CPU throttle
+2. `navigate_page` to the target URL
+3. `take_screenshot` for visual verification
+4. `take_snapshot` to verify responsive layout changes in the accessibility tree
+
+**Common device presets**:
+- iPhone 14: 390x844, deviceScaleFactor 3, mobile user agent
+- iPad: 810x1080, deviceScaleFactor 2, tablet user agent
+- Desktop: 1920x1080, no mobile emulation
+
+**Network throttling** (via `networkConditions` param):
+- `"Slow 3G"`, `"Fast 3G"`, `"Slow 4G"`, `"Fast 4G"`
+- `"Offline"` -- test offline behavior
+- `"No emulation"` -- reset to default
+
+---
+
+## Screenshot Capture
+
+Take screenshots for documentation or verification.
+
+1. `navigate_page` to the target URL
+2. `wait_for` expected text to appear on the page (confirming load is complete)
+3. `take_screenshot` -- captures the visible viewport
+
+**Full-page capture**: Use `fullPage` param. Note: very tall pages (e.g., Wikipedia articles) may return empty screenshot data due to an upstream MCP bug ([#571](https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/571)). If the screenshot is empty, retry without `fullPage` to capture just the viewport.
+
+**Device-specific screenshots**: Use `emulate` first to set viewport dimensions, then screenshot.
+
+**Tips**:
+- Wait for fonts, images, and animations to settle before capturing
+- For pages with lazy loading, scroll to trigger content load first
+- Use `resize_page` for custom viewport sizes without full device emulation
+- If `take_screenshot` returns empty data or triggers a 400 error, retry: (1) without `fullPage`, (2) with `filePath` to save to disk, (3) with a smaller viewport via `resize_page`
+
+**CRITICAL: Never use the Read tool on screenshot files.** Screenshots saved to disk via `filePath` can be very large (10+ MB for full-page captures). Reading them back into the conversation will crash the context or hit API image size limits. Instead, report the file path to the user and let them open it directly.
+
+---
+
+## Test Webapp Elements
+
+Navigate to a web app and verify elements exist and behave correctly.
+
+1. `navigate_page` to the target URL
+2. `take_snapshot` to get the accessibility tree
+3. Verify elements by text content and role:
+   - Buttons: role "button" with expected text
+   - Links: role "link" with expected href
+   - Inputs: role "textbox" with expected label
+   - Headings: appropriate heading level with expected text
+4. Test interactions: `click` buttons, `fill` inputs, verify state changes
+5. `take_screenshot` for visual verification of the final state

--- a/plugins/chrome-devtools/skills/guide/references/debugging-workflows.md
+++ b/plugins/chrome-devtools/skills/guide/references/debugging-workflows.md
@@ -1,0 +1,128 @@
+# Debugging Workflows
+
+Structured debugging workflows using Chrome DevTools MCP tools for console errors, network failures, and closed-loop fix cycles.
+
+---
+
+## Console Error Debugging
+
+Diagnose and resolve JavaScript errors and warnings surfaced in the browser console.
+
+1. `navigate_page` to the target URL
+2. Interact with the page to reproduce the issue (click, fill forms, navigate)
+3. `list_console_messages` with `types: ["error", "warning"]` -- filter to just errors and warnings (avoids noise from info/log messages)
+4. Scan the filtered results for actionable messages
+5. `get_console_message` on each error -- retrieve the full stack trace and message detail
+6. Analyze the stack trace to identify the source file, line number, and call chain
+7. `evaluate_script` to inspect live application state (note: `function` param takes an arrow function, not a bare expression):
+   - Check variable values: `() => JSON.stringify(window.__APP_STATE__)`
+   - Test DOM state: `() => document.querySelectorAll('.error').length`
+   - Verify API responses: `() => JSON.stringify(performance.getEntriesByType('resource').filter(r => r.initiatorType === 'fetch').map(r => ({ name: r.name, duration: r.duration })))`
+8. Suggest a fix based on the diagnosis
+
+**Common console error patterns**:
+
+| Error Pattern | Likely Cause | Investigation |
+|---------------|-------------|---------------|
+| `TypeError: Cannot read properties of undefined` | Accessing nested object before data loads | Check async data flow, look for missing null checks |
+| `CORS policy` errors | Backend missing Access-Control headers | Inspect the failing request with `get_network_request` |
+| `404` for script/asset | Wrong path or missing build artifact | Check `list_network_requests` with `resourceTypes: ["script"]` |
+| `Uncaught (in promise)` | Unhandled promise rejection | Look for missing `.catch()` or try/catch blocks |
+| `CSP violation` | Content Security Policy blocking inline scripts or external resources | Check CSP headers via `get_network_request` on the document |
+
+**Tips**:
+- Use `types: ["error", "warning"]` to filter out noise -- no need to wade through info/log messages
+- Console messages accumulate over time -- reproduce the issue on a fresh navigation for cleaner output
+- Use `includePreservedMessages: true` to see messages from the last 3 navigations (useful for redirect chains)
+- Use `pageIdx`/`pageSize` on `list_console_messages` if there are hundreds of entries
+- Pair console errors with network request analysis for a complete picture
+
+---
+
+## Network Request Debugging
+
+Diagnose failed API calls, CORS issues, authentication errors, and payload problems.
+
+1. `navigate_page` to the target URL
+2. Interact with the page to trigger the failing request
+3. `list_network_requests` with `resourceTypes: ["xhr", "fetch"]` -- isolate API calls from static assets
+4. Identify failed requests by status code (4xx, 5xx) or by missing expected requests
+5. `get_network_request` on the failing request -- inspect:
+   - **Request**: method, URL, headers (especially Authorization, Content-Type), body
+   - **Response**: status code, headers (especially CORS headers), body
+   - **Timing**: DNS, connection, TTFB, download duration
+
+**Diagnosing by status code**:
+
+| Status | Common Cause | What to Check |
+|--------|-------------|---------------|
+| 400 Bad Request | Malformed payload | Request body shape, Content-Type header |
+| 401 Unauthorized | Missing or expired token | Authorization header, token expiry |
+| 403 Forbidden | Insufficient permissions | User role, CORS preflight response |
+| 404 Not Found | Wrong endpoint URL | API base URL, path params |
+| 405 Method Not Allowed | Wrong HTTP method | POST vs PUT vs PATCH |
+| 422 Unprocessable | Validation failure | Response body for field-level errors |
+| 500 Internal Server | Backend crash | Response body for error details |
+
+**CORS debugging**:
+1. Look for a preflight `OPTIONS` request preceding the failed request
+2. Check the response headers on the preflight:
+   - `Access-Control-Allow-Origin` -- must match the page origin or be `*`
+   - `Access-Control-Allow-Methods` -- must include the request method
+   - `Access-Control-Allow-Headers` -- must include custom headers (e.g., Authorization)
+3. If no preflight exists, the browser treated it as a simple request -- check `Access-Control-Allow-Origin` on the main response
+
+**Tips**:
+- Use `responseFilePath` param on `get_network_request` for large response bodies (JSON APIs returning megabytes of data). Use `requestFilePath` to save request bodies separately.
+- Use `includePreservedRequests: true` on `list_network_requests` to see requests across the last 3 navigations (useful for redirect chains and SPA route changes)
+- Filter by `resourceTypes` to avoid wading through hundreds of image/font/stylesheet requests
+- Check `list_network_requests` timing data to identify slow backend responses vs network latency
+
+---
+
+## Closed-Loop Debug-Fix Cycle
+
+A full reproduce-analyze-fix-verify loop for interactive debugging.
+
+### The Loop
+
+```
+Navigate -> Reproduce -> Analyze -> Hypothesize -> Test -> Verify
+    ^                                                        |
+    +--------------------------------------------------------+
+    (repeat until fixed)
+```
+
+### Step-by-step
+
+1. **Navigate**: `navigate_page` to the target URL
+2. **Reproduce**: Perform the exact steps that trigger the bug (click, fill, submit)
+3. **Analyze**: Gather evidence from multiple sources:
+   - `list_console_messages` -- JavaScript errors and warnings
+   - `list_network_requests` with `resourceTypes: ["xhr", "fetch"]` -- API failures
+   - `take_snapshot` -- current DOM/accessibility state
+4. **Hypothesize**: Based on the evidence, form a theory about the root cause
+5. **Test**: Use `evaluate_script` to validate the hypothesis:
+   - Inspect application state
+   - Check DOM element properties
+   - Test a potential fix in-browser (e.g., patching a function, setting a value)
+6. **Verify**: `take_screenshot` to confirm the fix visually, plus re-check console and network for clean output
+
+### Example: Form Submission Bug
+
+```
+1. navigate_page -> "https://app.example.com/settings"
+2. take_snapshot -> find the form fields
+3. fill -> populate fields, click submit
+4. list_console_messages -> "TypeError: Cannot read properties of undefined (reading 'email')"
+5. get_console_message -> stack trace points to validateForm() line 42
+6. evaluate_script -> function: "() => JSON.stringify(document.querySelector('form').elements.email.value)"
+   -> reveals the email field has name="user-email" not name="email"
+7. Report: form field name mismatch, validateForm() expects 'email' but field is 'user-email'
+```
+
+**Tips**:
+- Always start with a fresh navigation to avoid stale state from previous debugging
+- Capture a screenshot at each stage for a visual record of the debugging journey
+- Use `evaluate_script` conservatively -- avoid modifying production state accidentally
+- If the bug is intermittent, reproduce multiple times and compare console/network output across attempts

--- a/plugins/chrome-devtools/skills/guide/references/diagnostics.md
+++ b/plugins/chrome-devtools/skills/guide/references/diagnostics.md
@@ -1,0 +1,300 @@
+# Diagnostics
+
+Error recovery matrix and connection troubleshooting for Chrome DevTools MCP.
+
+---
+
+## Error Recovery Matrix
+
+| Failure | Detector | Action | Fallback |
+|---------|----------|--------|----------|
+| Element not found | `take_snapshot` no UID match | Re-snapshot, try alternative labels | Screenshot + manual instructions |
+| Navigation timeout | `wait_for` exceeds timeout | Screenshot current page | Manual navigation steps |
+| Empty screenshot | `take_screenshot` returns empty/0-byte data or API 400 "image cannot be empty" | Retry without `fullPage`. If still empty, retry with `filePath` to save to disk. If still empty, reduce viewport with `resize_page` | Known upstream bug ([#571](https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/571)). Report failure, suggest manual screenshot |
+| 2FA prompt | Snapshot shows auth dialog | Tell user to dismiss, `wait_for` | Wait for user, resume |
+| Chrome crash | Tool returns connection error | Report, provide startup cmd | STOP workflow |
+| MCP disconnected | Tool call fails | Run layered diagnostics | Point to `/chrome-devtools:fix` |
+
+---
+
+## Layered Diagnostic Flow
+
+Each layer narrows the root cause. Stop at the first conclusive result.
+
+### Layer 1: MCP Probe
+
+Call `list_pages` via Chrome DevTools MCP.
+- **Success**: Connection healthy. Report page count and proceed.
+- **Tool not available** (not in tool list): MCP tools aren't registered in this session. Report and STOP -- do not continue to Layer 2 (this is a session config issue, not a connection issue).
+- **Tool returns error**: Continue to Layer 2.
+
+### Layer 2: Port Check
+
+```bash
+lsof -i :9222 -sTCP:LISTEN 2>/dev/null
+```
+- **Port in use**: Something is listening. Extract PID and process name. If it's not Chrome or the MCP, it's a port conflict.
+- **Port free**: Nothing listening on 9222. Continue to Layer 3.
+
+### Layer 3: Chrome Debug Endpoint
+
+```bash
+curl -s --max-time 3 http://localhost:9222/json/version
+```
+- **Response**: Chrome is running with debug port. Parse the `Browser` field (e.g., `"Chrome/144.0.6367.60"`) and report the version. If Chrome >= 144, note auto-connect availability (`--autoConnect`). The issue is MCP transport.
+- **No response**: Chrome is not running with remote debugging enabled.
+
+### Layer 4: MCP Process Check
+
+```bash
+ps aux | grep -c '[c]hrome-devtools-mcp'
+```
+- **Process found**: MCP is running but can't connect to Chrome. Transport issue.
+- **Not found**: MCP server is not running or not configured.
+
+---
+
+## Fix Command Scenario Table
+
+Used by `/chrome-devtools:fix` to map diagnostic results to actions.
+
+| Problem | Layer Detected | Detection Method | Diagnosis Message | Fix Options |
+|---------|---------------|------------------|-------------------|-------------|
+| Stale process on port | Layer 2 | `lsof` shows PID not matching MCP | "Port 9222 held by PID {pid} ({process})" | Kill PID / use `--isolated` / manual |
+| Profile locked | Layer 1 | `list_pages` returns "browser already running" | "Chrome profile locked by another instance" | Clear SingletonLock / `--isolated` / restart MCP |
+| Chrome not running | Layer 2+3 | Port free, curl fails | "Chrome not running with debug port" | Launch Chrome / `--isolated` / `--autoConnect` |
+| MCP transport broken | Layer 3+4 | curl succeeds, MCP process exists but list_pages fails | "MCP can't connect to Chrome" | Restart MCP / `--isolated` |
+| MCP not running | Layer 4 | No MCP process found | "MCP server not running" | Restart MCP / re-add server |
+| MCP tools not registered | Layer 1 | `list_pages` not in tool list (MCP may show "connected" with 0 tools) | "Chrome DevTools MCP tools are not registered in this session" | Run `/doctor` to diagnose MCP connectivity |
+| MCP not configured | Layer 1 | ToolSearch returns no chrome-devtools tools | "Chrome DevTools MCP not configured or enabled" | Run `/doctor` to diagnose MCP connectivity |
+| Everything healthy | Layer 1 | `list_pages` succeeds | "Connection healthy. {N} pages open." | No action needed |
+
+---
+
+## Connection Troubleshooting
+
+### Port Conflicts
+
+```bash
+# Find what's using port 9222
+lsof -i :9222 -sTCP:LISTEN
+
+# Kill a specific PID
+kill <PID>
+
+# If Chrome is running without debug port, restart with:
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.chrome-debug-profile"
+```
+
+### Manual Connection (`--browserUrl`) -- Recommended
+
+The most reliable method for connecting to an existing Chrome instance. You launch Chrome yourself with `--remote-debugging-port` and point the MCP at it. No permission dialogs, works with any Chrome version.
+
+**Step 1: Launch Chrome with remote debugging**
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.chrome-debug-profile"
+```
+
+**Security note**: Chrome requires a non-default `--user-data-dir` when using `--remote-debugging-port`. Chrome refuses to expose your default profile to the debug port -- this is intentional security hardening. Use a dedicated debug profile directory.
+
+**Step 2: Configure the MCP server**
+
+```json
+{
+  "command": "bunx",
+  "args": [
+    "chrome-devtools-mcp@latest",
+    "--browserUrl=http://localhost:9222"
+  ]
+}
+```
+
+**Best for**: Daily development workflows, persistent sessions with login state, CI pipelines where Chrome is pre-launched.
+**Trade-off**: Requires manually launching Chrome with the debug flags (or adding to a shell alias/startup script).
+
+### Isolated Mode
+
+Use `--isolated` for a temporary user data directory. This prevents profile locks but loses session state (cookies, logins):
+
+```json
+{
+  "command": "bunx",
+  "args": [
+    "chrome-devtools-mcp@latest",
+    "--isolated"
+  ]
+}
+```
+
+**When to use**: Profile lock errors, testing in clean state, avoiding conflicts with main Chrome.
+**Trade-off**: Must re-authenticate on every session.
+
+### Auto-Connect (Chrome 144+)
+
+Connects to your already-running Chrome without needing `--remote-debugging-port`. Chrome 144+ exposes a native DevTools protocol endpoint that the MCP can discover automatically.
+
+**Setup:**
+
+1. Open `chrome://inspect/#remote-debugging` in Chrome and ensure remote debugging is enabled
+2. Configure the MCP server with `--autoConnect`:
+
+```json
+{
+  "command": "bunx",
+  "args": [
+    "chrome-devtools-mcp@latest",
+    "--autoConnect"
+  ]
+}
+```
+
+Optionally target a specific Chrome channel: `--channel=beta`, `--channel=canary`, or `--channel=dev`.
+
+**Best for**: Auth-gated sites (uses existing cookies/sessions), manual-to-AI debugging handoff, ad-hoc debugging sessions.
+
+**Known friction:**
+- Chrome shows a permission dialog on every MCP connection -- there is no "Always allow" option yet
+- On macOS, auto-connect cannot use your main Chrome profile if Chrome is already running; you may need a separate profile
+- Suspended tabs (from "Continue where you left off") can cause connection timeouts -- disable this Chrome setting or close stale tabs
+
+**When `--browserUrl` is better**: For persistent, frictionless daily-driver sessions, launch Chrome yourself with `--remote-debugging-port=9222` and `--user-data-dir` and use `--browserUrl` instead. No permission dialogs, works with any Chrome version.
+
+### WebSocket Connection (`--wsEndpoint`)
+
+For remote browsers, sandboxed environments (e.g., Docker), or authenticated endpoints like Browserless.
+
+**Step 1: Find the WebSocket URL**
+
+```bash
+curl -s http://localhost:9222/json/version | jq -r '.webSocketDebuggerUrl'
+# Example output: ws://127.0.0.1:9222/devtools/browser/a1b2c3d4-e5f6-...
+```
+
+**Step 2: Configure the MCP server**
+
+```json
+{
+  "command": "bunx",
+  "args": [
+    "chrome-devtools-mcp@latest",
+    "--wsEndpoint=ws://127.0.0.1:9222/devtools/browser/<id>"
+  ]
+}
+```
+
+For authenticated WebSocket endpoints (e.g., Browserless), add `--wsHeaders`:
+
+```json
+{
+  "command": "bunx",
+  "args": [
+    "chrome-devtools-mcp@latest",
+    "--wsEndpoint=wss://chrome.browserless.io",
+    "--wsHeaders={\"Authorization\": \"Bearer <token>\"}"
+  ]
+}
+```
+
+**Best for**: Remote/cloud browsers, Docker containers, Browserless/BrowserBase, environments where HTTP connectivity to `localhost:9222` is not available.
+**Trade-off**: Requires obtaining the WebSocket URL first, and the URL changes on each Chrome restart.
+
+### Custom Profile (`--userDataDir`)
+
+Override the default Chrome profile directory used by the MCP. By default, the MCP stores its profile at `~/.cache/chrome-devtools-mcp/chrome-profile-stable`.
+
+```json
+{
+  "command": "bunx",
+  "args": [
+    "chrome-devtools-mcp@latest",
+    "--userDataDir=/path/to/custom/profile"
+  ]
+}
+```
+
+**When to use**: Sharing state with a specific Chrome profile, team-standardized profiles, persisting extensions across sessions, separating profiles for different projects.
+**Trade-off**: Profile directory must not be in use by another Chrome instance (or you'll get a profile lock error).
+
+### Profile Lock Recovery
+
+If Chrome crashes and leaves a stale lock:
+
+```bash
+# Find and remove the lock file
+rm -f "$HOME/.chrome-debug-profile/SingletonLock"
+```
+
+Then restart the MCP or Chrome.
+
+### MCP Server Restart
+
+If the MCP server needs a full restart:
+
+1. Run `/doctor` to diagnose and restart the MCP server
+2. Run `/chrome-devtools:fix --check` to verify
+
+### Headless Mode
+
+For CI or environments without a display:
+
+```json
+{
+  "command": "bunx",
+  "args": [
+    "chrome-devtools-mcp@latest",
+    "--headless"
+  ]
+}
+```
+
+**Trade-off**: No visual Chrome window. Screenshots still work but user can't interact manually.
+
+### When MCP Is Insufficient
+
+Some tasks require the full Chrome DevTools UI:
+- Memory profiling with heap snapshots
+- Advanced network throttling profiles
+- Service worker debugging
+- WebSocket frame inspection
+
+Guide the user to open Chrome DevTools manually (`Cmd+Option+I`) for these cases.
+
+---
+
+## Server Flags Quick Reference
+
+Complete inventory of `chrome-devtools-mcp` server flags for troubleshooting and configuration.
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--browserUrl` | Connect to Chrome at a specific debug URL | `--browserUrl=http://localhost:9222` |
+| `--wsEndpoint` | Connect via WebSocket URL | `--wsEndpoint=ws://127.0.0.1:9222/devtools/browser/<id>` |
+| `--wsHeaders` | Headers for authenticated WebSocket endpoints | `--wsHeaders={"Authorization": "Bearer <token>"}` |
+| `--autoConnect` | Auto-discover running Chrome (144+) | `--autoConnect` |
+| `--channel` | Target Chrome channel (with `--autoConnect`) | `--channel=canary` |
+| `--isolated` | Use temporary profile directory | `--isolated` |
+| `--userDataDir` | Custom Chrome profile directory | `--userDataDir=/path/to/profile` |
+| `--headless` | Run Chrome without a visible window | `--headless` |
+| `--proxyServer` | Route Chrome traffic through a proxy | `--proxyServer=http://proxy:8080` |
+| `--acceptInsecureCerts` | Accept self-signed/invalid TLS certificates | `--acceptInsecureCerts` |
+| `--chromeArg` | Pass arbitrary flags to Chrome (repeatable) | `--chromeArg=--disable-extensions` |
+
+---
+
+## Upstream Reference
+
+When encountering unfamiliar errors or checking for new features:
+
+- **Repository**: https://github.com/ChromeDevTools/chrome-devtools-mcp
+- **README (flags, config)**: `gh api repos/ChromeDevTools/chrome-devtools-mcp/readme --jq '.content' | base64 -d`
+- **Open issues**: `gh search issues --repo ChromeDevTools/chrome-devtools-mcp "<error message>" --limit 5`
+- **Releases/changelog**: `gh release list --repo ChromeDevTools/chrome-devtools-mcp --limit 5`
+- **Troubleshooting doc**: `gh api repos/ChromeDevTools/chrome-devtools-mcp/contents/docs/troubleshooting.md --jq '.content' | base64 -d`
+- **Latest version**: check `npm view chrome-devtools-mcp version`
+
+Current version at time of writing: v0.17.0 (2026-02-10)

--- a/plugins/chrome-devtools/skills/guide/references/publishing-workflows.md
+++ b/plugins/chrome-devtools/skills/guide/references/publishing-workflows.md
@@ -1,0 +1,335 @@
+# Publishing Workflows
+
+Browser automation workflows for npm and GitHub setup tasks. Each workflow uses Chrome DevTools MCP tools to drive Chrome with remote debugging.
+
+---
+
+## General Patterns
+
+### Auth Detection
+
+Before any workflow, check login state:
+
+1. `navigate_page` to the target site root (e.g., `https://www.npmjs.com`)
+2. `take_snapshot`
+3. Look for indicators:
+   - **Logged in**: Username/avatar in snapshot, profile menu items
+   - **Not logged in**: "Sign In", "Log in", "Sign Up" text present
+4. If not logged in: Tell the user to log in manually in the debug profile, then `wait_for` authenticated state
+
+### 1Password Vault Storage
+
+When secrets are created (npm tokens, API keys), offer to store them in 1Password via the `op` CLI. This avoids clipboard exposure and creates an audit trail.
+
+**Detection**: Check if `op` is available before offering:
+```bash
+op --version 2>/dev/null
+```
+
+**Vault**: `API Credentials` -- the sole vault. No resolution logic needed.
+
+**Auth**: `OP_SERVICE_ACCOUNT_TOKEN` is set in the shell environment (sourced from `~/code/dotfiles/.env`). All `op` commands run non-interactively -- no Touch ID prompts, fully automatable.
+
+**Store a secret**:
+```bash
+op item create \
+  --category=api_credential \
+  --title="<TITLE>" \
+  --vault="API Credentials" \
+  "credential=<SECRET_VALUE>" \
+  "type=<TYPE>" \
+  "expires=<EXPIRY_DATE>"
+```
+
+**Retrieve a secret**:
+```bash
+op read "op://API Credentials/<ITEM>/<FIELD>"
+```
+
+**Check for existing items** (before creating duplicates):
+```bash
+op item list --vault="API Credentials" --format=json | grep -i "<SEARCH_TERM>"
+```
+
+**Conventions**:
+- **Title format**: `<service> - <purpose>` (e.g., "npm - github-actions-publish token")
+- **Tags**: Add relevant tags (e.g., `npm`, `ci-cd`, `github-actions`)
+- **Notes field**: Include context -- which repo, what scope, when it expires
+- **Expiry tracking**: Set the expiry date so 1Password can warn before it lapses
+
+**Graceful degradation**: If `op` is not installed, `OP_SERVICE_ACCOUNT_TOKEN` is not set, or the user declines, fall back to manual copy + `gh secret set`.
+
+---
+
+## Workflows
+
+### npm-create-token
+
+**Task**: Create a granular access token on npmjs.com
+**Why browser**: No CLI equivalent for granular token creation with custom scopes.
+
+**Variables needed**:
+- `TOKEN_NAME` -- descriptive name (e.g., "github-actions-publish")
+- `EXPIRY` -- token expiry period (default: 90 days)
+- `PACKAGE_SCOPE` -- package or scope to grant access to
+- `PERMISSIONS` -- Read and Write (for publishing)
+
+**Steps**:
+
+1. **Navigate** to token creation page
+   ```
+   navigate_page -> https://www.npmjs.com/settings/<username>/tokens/granular-access-tokens/new
+   wait_for -> text "Generate a granular access token"
+   ```
+
+2. **Verify auth** -- `take_snapshot`, confirm no login redirect
+
+3. **Fill token name**
+   ```
+   take_snapshot -> find textbox with label "Token name" or "Name"
+   fill -> TOKEN_NAME value
+   ```
+
+4. **Set expiry**
+   ```
+   take_snapshot -> find dropdown/select near "Expiration"
+   click -> expiry option (90 days recommended)
+   ```
+
+5. **Configure package scope**
+   ```
+   take_snapshot -> find "Packages and scopes" section
+   select -> "Only select packages and scopes"
+   fill -> PACKAGE_SCOPE in the package/scope input
+   ```
+
+6. **Set permissions**
+   ```
+   take_snapshot -> find permissions section
+   select -> "Read and Write" for the package scope
+   ```
+
+7. **Screenshot BEFORE generating** (for verification -- NEVER after)
+   ```
+   take_screenshot -> capture the filled form for verification
+   ```
+
+8. **Generate token**
+   ```
+   take_snapshot -> find button with text "Generate token" or "Generate Token"
+   click -> the generate button
+   wait_for -> token value display (text starting with "npm_")
+   ```
+
+9. **Extract token value** (text only -- NO screenshots)
+   ```
+   take_snapshot -> find the token value (starts with "npm_")
+   ```
+   - Display only first 8 characters: `npm_1234abcd...`
+   - **CRITICAL**: Warn user this token is shown only once
+
+10. **Store the token** (offer in priority order)
+    1. **1Password** (if `op` available): Store with expiry tracking
+       ```bash
+       op item create --category=api_credential \
+         --title="npm - TOKEN_NAME" \
+         --vault="API Credentials" \
+         "credential=<token_value>" \
+         "type=granular_access_token" \
+         "scope=PACKAGE_SCOPE" \
+         "expires=<90 days from now>"
+       ```
+    2. **GitHub secret**: Pipe to `gh secret set NPM_TOKEN` for CI usage
+       ```bash
+       echo "<token_value>" | gh secret set NPM_TOKEN --repo <OWNER>/<REPO>
+       ```
+    3. **Manual**: Tell user to copy and store it themselves
+
+    Offer all applicable options -- the user may want both vault storage AND the GitHub secret set.
+
+**Verification**: Token value starts with `npm_` and is stored successfully.
+
+---
+
+### npm-oidc-setup
+
+**Task**: Configure OpenID Connect trusted publishing for a package
+**Why browser**: OIDC trusted publisher setup has no CLI equivalent.
+
+**Variables needed**:
+- `PACKAGE_NAME` -- npm package name
+- `GITHUB_ORG_OR_USER` -- GitHub org or username
+- `GITHUB_REPO` -- repository name
+- `WORKFLOW_FILE` -- workflow filename (default: `publish.yml`)
+
+**Steps**:
+
+1. **Navigate** to package access page
+   ```
+   navigate_page -> https://www.npmjs.com/package/<PACKAGE_NAME>/access
+   wait_for -> text "Publishing access" or "Access"
+   ```
+
+2. **Verify auth** -- `take_snapshot`, confirm logged in as package owner
+
+3. **Find trusted publisher section**
+   ```
+   take_snapshot -> find "Trusted Publisher" or "GitHub Actions" section
+   ```
+   - If not visible, fall back to manual instructions
+
+4. **Select GitHub Actions**
+   ```
+   click -> "GitHub Actions" option or "Configure trusted publisher"
+   wait_for -> form fields for GitHub org/repo/workflow
+   ```
+
+5. **Fill GitHub details**
+   ```
+   take_snapshot -> find form fields
+   fill -> GITHUB_ORG_OR_USER in org/username field
+   fill -> GITHUB_REPO in repository field
+   fill -> WORKFLOW_FILE in workflow filename field
+   ```
+
+6. **Submit**
+   ```
+   take_snapshot -> find button "Set up connection" or "Save" or "Configure"
+   click -> the submit button
+   wait_for -> success confirmation
+   ```
+
+7. **Verify**
+   ```
+   take_screenshot -> capture confirmation
+   take_snapshot -> confirm trusted publisher is now listed
+   ```
+
+**Verification**: Page shows the GitHub repository as a trusted publisher.
+
+---
+
+### npm-view-access
+
+**Task**: View current access configuration for a package
+**Why browser**: Quick visual audit of publishing method, trusted publishers, 2FA requirements.
+
+**Variables needed**:
+- `PACKAGE_NAME` -- npm package name
+
+**Steps**:
+
+1. **Navigate**
+   ```
+   navigate_page -> https://www.npmjs.com/package/<PACKAGE_NAME>/access
+   wait_for -> page load
+   ```
+
+2. **Capture state**
+   ```
+   take_snapshot -> full accessibility tree
+   take_screenshot -> visual record
+   ```
+
+3. **Report** the following from the snapshot:
+   - Current publishing method (token, OIDC, or both)
+   - Trusted publisher configuration (if any)
+   - 2FA requirements
+   - Team/user access list
+
+---
+
+### github-set-secret
+
+**Task**: Set a repository secret
+**Preferred method**: CLI (`gh secret set`), with optional 1Password sourcing
+
+**CLI method** (preferred):
+```bash
+# Direct value:
+echo "<SECRET_VALUE>" | gh secret set <SECRET_NAME> --repo <OWNER>/<REPO>
+
+# From 1Password (if op available and secret is vaulted):
+op read "op://API Credentials/<ITEM>/credential" | gh secret set <SECRET_NAME> --repo <OWNER>/<REPO>
+```
+
+When `op` is available, check if the secret already exists in the vault before asking the user to provide it manually.
+
+**Browser fallback** (when `gh` unavailable):
+
+1. `navigate_page` -> `https://github.com/<OWNER>/<REPO>/settings/secrets/actions`
+2. `wait_for` -> text "Actions secrets" or "Repository secrets"
+3. `take_snapshot` -> find "New repository secret" button, `click` it
+4. `fill` -> SECRET_NAME in "Name" field
+5. `fill` -> SECRET_VALUE in "Secret" / "Value" field
+6. `take_snapshot` -> find "Add secret" button, `click` it
+7. `take_snapshot` -> confirm secret appears in the list
+
+---
+
+### github-branch-protection
+
+**Task**: Configure branch protection rules
+**Preferred method**: CLI (`gh api`)
+
+**CLI method** (preferred):
+```bash
+gh api repos/<OWNER>/<REPO>/branches/main/protection \
+  --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {"strict": true, "contexts": ["pr-quality"]},
+  "enforce_admins": true,
+  "required_pull_request_reviews": {"required_approving_review_count": 1}
+}
+EOF
+```
+
+**Browser fallback** (when `gh` unavailable):
+
+1. `navigate_page` -> `https://github.com/<OWNER>/<REPO>/settings/branches`
+2. `take_snapshot` -> find existing rule or "Add branch protection rule"
+3. Fill branch name pattern, enable required status checks, enable PR reviews
+4. `click` save button
+5. `take_screenshot` -> visual confirmation
+
+---
+
+## Edge Cases
+
+### 2FA Prompts
+
+npm and GitHub may prompt for 2FA during sensitive operations:
+
+1. `take_snapshot` -- detect 2FA prompt (text like "Two-factor authentication", "Verify", "Enter code")
+2. Tell the user: _"A 2FA prompt appeared. Please enter your code in the browser, then tell me when you're done."_
+3. `wait_for` the 2FA form to disappear
+4. Resume the workflow
+
+### Secret Screenshot Safety
+
+```
+CRITICAL: After clicking "Generate token" or any action that reveals a secret:
+- NEVER call take_screenshot -- the token would be persisted as an image
+- Use take_snapshot (text only) to extract the token value
+- Display only first 8 characters to the user: npm_1234abcd...
+- Immediately offer storage (1Password -> gh secret set -> manual copy)
+```
+
+### UI Changes
+
+npm and GitHub periodically update their UI. The snapshot-first approach handles this:
+
+- Element finding uses **text content and roles**, not CSS selectors or coordinates
+- If expected text isn't found, search for **alternative labels** (e.g., "Generate" vs "Create", "Save" vs "Submit")
+- If no matching element is found after alternatives, fall back to manual instructions with a screenshot of what's currently on screen
+
+### Not Logged In
+
+If a login page is detected at any point during a workflow:
+
+1. `take_screenshot` -- show the user what's on screen
+2. Instruct: _"You need to log in to [site] in the debug Chrome profile. Please log in, then tell me when you're ready."_
+3. `wait_for` -- wait for the authenticated page to load
+4. Re-run `take_snapshot` to verify login succeeded
+5. Resume the workflow from the interrupted step

--- a/plugins/chrome-devtools/skills/guide/references/tools.md
+++ b/plugins/chrome-devtools/skills/guide/references/tools.md
@@ -1,0 +1,135 @@
+# Tools Reference
+
+High-signal Chrome DevTools MCP tools. These 10 cover 90%+ of use cases.
+
+---
+
+## Top 10 Tools
+
+### 1. navigate_page
+
+Navigate to a URL in the active tab.
+
+**Key params**: `url` (required with `type: "url"`), `type` (optional: "url", "back", "forward", "reload"), `timeout` (optional: ms), `initScript` (optional: JS to run before any page scripts on next navigation), `handleBeforeUnload` (optional: "accept" or "decline")
+**When to use**: Starting any workflow, navigating between pages. Use `type: "reload"` to refresh. Use `initScript` to mock APIs or patch globals before the app boots.
+**Common mistake**: Not calling `wait_for` after navigation to ensure the page has loaded before taking snapshots.
+
+### 2. take_snapshot
+
+Get the accessibility tree for the active page. Returns element UIDs for interaction.
+
+**Key params**: `verbose` (optional: include full a11y tree detail), `filePath` (optional: save to file)
+**When to use**: Before ANY element interaction. This is your primary element discovery tool.
+**Common mistake**: Using `take_screenshot` for element finding instead of snapshot.
+
+### 3. take_screenshot
+
+Capture a visual screenshot of the active page.
+
+**Key params**: `filePath` (optional: save to file instead of inline), `fullPage` (optional), `format` (optional: "png", "jpeg", "webp"), `quality` (optional: 0-100 for jpeg/webp), `uid` (optional: screenshot a specific element)
+**When to use**: Visual verification after actions. NEVER after a secret is revealed.
+**Common mistake**: Using screenshots for element discovery (use snapshot instead).
+
+### 4. click
+
+Click an element identified by UID from a snapshot.
+
+**Key params**: `uid` (required: from take_snapshot), `dblClick` (optional: true for double-click), `includeSnapshot` (optional: return updated snapshot)
+**When to use**: After take_snapshot identifies the target element.
+**Common mistake**: Using stale UIDs from a previous snapshot after page state changed.
+
+### 5. fill
+
+Type text into an input element identified by UID.
+
+**Key params**: `uid` (required), `value` (required)
+**When to use**: Filling text inputs, search fields, form fields.
+**Common mistake**: Not clearing existing text first (fill replaces content).
+
+### 6. wait_for
+
+Wait for text to appear on the page before proceeding.
+
+**Key params**: `text` (required: text to wait for), `timeout` (optional: ms, 0 for default)
+**When to use**: After navigation, form submission, or any async operation. Always use after `navigate_page`.
+**Common mistake**: Setting timeout too low for slow pages.
+
+### 7. list_pages
+
+Enumerate all open browser tabs.
+
+**Key params**: None required. Returns pageId, URL, title for each tab.
+**When to use**: Finding a specific tab, checking connection health, multi-tab workflows.
+**Common mistake**: Assuming which tab is active without checking.
+
+### 8. select_page
+
+Switch the active tab by pageId.
+
+**Key params**: `pageId` (required: from list_pages)
+**When to use**: Multi-tab workflows, switching between pages.
+**Common mistake**: Not re-snapshotting after switching tabs.
+
+### 9. evaluate_script
+
+Execute a JavaScript function in the page context. Returns JSON-serializable results.
+
+**Key params**: `function` (required: JS function declaration, e.g., `() => document.title`), `args` (optional: array of `{uid}` objects to pass snapshot elements as arguments)
+**When to use**: Reading page state, extracting data, triggering JS-only interactions.
+**Common mistake**: Running destructive scripts without user confirmation. Return values must be JSON-serializable.
+
+### 10. list_network_requests
+
+List captured network requests with filtering.
+
+**Key params**: `resourceTypes` (optional: array of types like `["xhr", "fetch"]`), `pageIdx`/`pageSize` (pagination), `includePreservedRequests` (optional: include requests from last 3 navigations)
+**When to use**: Network monitoring, API debugging, performance analysis.
+**Common mistake**: Not paginating with `pageIdx`/`pageSize` on busy pages (can return hundreds of entries).
+
+---
+
+## Remaining Tools (by category)
+
+### Input
+
+- **fill_form** -- fill multiple form fields at once (batch version of fill)
+- **hover** -- hover over an element by UID (triggers tooltips, dropdowns)
+- **press_key** -- send keyboard input (Enter, Tab, Escape, shortcuts)
+- **drag** -- drag from one element to another by UIDs
+- **upload_file** -- upload a file to a file input element
+- **handle_dialog** -- accept or dismiss browser dialogs (alert, confirm, prompt)
+
+### Navigation
+
+- **new_page** -- open a new browser tab (optionally with URL)
+- **close_page** -- close a tab by pageId
+
+### Emulation
+
+- **emulate** -- set device viewport, user agent, network conditions, CPU throttle
+- **resize_page** -- resize the browser viewport to specific dimensions
+
+### Performance
+
+- **performance_start_trace** -- begin recording. Requires `reload` (bool) and `autoStop` (bool). Optional `filePath` for raw trace data.
+- **performance_stop_trace** -- stop recording and get trace data. Optional `filePath`.
+- **performance_analyze_insight** -- drill into a specific insight. Requires `insightSetId` and `insightName` (from trace results).
+
+### Network
+
+- **get_network_request** -- get detailed info for a specific request. Use `responseFilePath`/`requestFilePath` to save large bodies to disk
+
+### Debugging
+
+- **get_console_message** -- get a specific console message by index
+- **list_console_messages** -- list console messages. Use `types` filter (e.g., `["error", "warning"]`) and `includePreservedMessages` for cross-navigation history
+
+---
+
+## Core Web Vitals Thresholds
+
+| Metric | Good | Needs Improvement | Poor |
+|--------|------|-------------------|------|
+| INP (Interaction to Next Paint) | <= 200ms | <= 500ms | > 500ms |
+| LCP (Largest Contentful Paint) | <= 2.5s | <= 4.0s | > 4.0s |
+| CLS (Cumulative Layout Shift) | <= 0.1 | <= 0.25 | > 0.25 |


### PR DESCRIPTION
## Summary

- Scope Bash `allowed-tools` to 7 specific command patterns (was unrestricted)
- Add natural language trigger phrases to skill description for better auto-triggering
- Deduplicate content between SKILL.md and reference files (connection check, auth detection, 1Password)
- Rename core skill from `chrome-devtools` to `guide` (fixes `/chrome-devtools:chrome-devtools` stutter)
- Replace deprecated `/mcp-manager:enable|disable` references with `/doctor` across 4 files

Closes stutter issue where the skill displayed as `/chrome-devtools:chrome-devtools`. Now invoked as `/chrome-devtools:guide`.

## Test plan

- [ ] Invoke `/chrome-devtools:guide` -- verify skill loads with correct description
- [ ] Invoke `/chrome-devtools:fix` -- verify `/doctor` references work
- [ ] Invoke `/chrome-devtools:automate` -- verify it references the guide skill correctly
- [ ] Verify no remaining `/mcp-manager:enable` references: `grep -r "mcp-manager" plugins/chrome-devtools/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated diagnostic workflow to use `/doctor` command for improved troubleshooting and MCP connectivity checks.

* **Chores**
  * Updated plugin documentation and internal skill references for consistency.
  * Expanded tool support and streamlined diagnostic procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->