### PR TITLE
feat(claude-code): add mcp-guide knowledge bank skill

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "claude-code",
 	"version": "1.0.0",
-	"description": "Knowledge bank for Claude Code hooks and skills - event lifecycle, hook types, configuration, community patterns, skill authoring, design patterns, and troubleshooting.",
+	"description": "Knowledge bank for Claude Code hooks, skills, and MCP servers - event lifecycle, hook types, configuration, community patterns, skill authoring, MCP setup, Tool Search, design patterns, and troubleshooting.",
 	"author": {
 		"name": "Nathan Vale"
 	},
@@ -10,6 +10,9 @@
 		"hooks",
 		"plugins",
 		"skills",
+		"mcp",
+		"mcp-servers",
+		"tool-search",
 		"automation",
 		"PreToolUse",
 		"PostToolUse",
@@ -24,6 +27,7 @@
 		"./skills/skills-guide",
 		"./skills/skill-builder",
 		"./skills/skill-reviewer",
-		"./skills/skill-smoketest"
+		"./skills/skill-smoketest",
+		"./skills/mcp-guide"
 	]
 }

--- a/plugins/claude-code/skills/mcp-guide/SKILL.md
+++ b/plugins/claude-code/skills/mcp-guide/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: mcp-guide
+description: >
+  Knowledge bank for Claude Code MCP servers -- setup, installation scopes,
+  Tool Search, lazy loading, configuration, plugin MCP servers, managed policies,
+  best practices, and troubleshooting.
+  Triggers on: MCP server, MCP tools, add MCP, install MCP, .mcp.json,
+  mcp configuration, mcp scope, local vs project vs user MCP, Tool Search,
+  lazy loading, ENABLE_TOOL_SEARCH, MCP output limits, MAX_MCP_OUTPUT_TOKENS,
+  MCP timeout, MCP not working, MCP server not connecting, mcp permission,
+  managed-mcp.json, allowedMcpServers, deniedMcpServers, MCP in plugin,
+  plugin MCP server, MCP resources, MCP prompts, remote MCP, SSE, stdio,
+  HTTP MCP, MCP vs skills, when to use MCP, MCP cost, MCP context,
+  mcp-server, connect tool, external tool.
+allowed-tools: Read, Glob, Grep
+---
+
+# Claude Code MCP Guide -- Knowledge Bank
+
+Expert guidance for connecting Claude Code to external tools via MCP (Model Context Protocol). Covers server setup, configuration scopes, Tool Search, plugin integration, best practices, and troubleshooting.
+
+## Source Authority
+
+This skill draws from:
+- Official Claude Code documentation at code.claude.com/docs/en/mcp
+- Anthropic engineering blog posts on MCP patterns
+- Claude Code settings and configuration reference
+- Plugin system reference documentation
+
+## Community Perspective (Opt-In)
+
+This skill does NOT maintain a community intel cache. For live community signal on MCP usage patterns, hand off to `/research:newsroom` when the user asks for community perspective.
+
+**Auto-detect these signals** -- if the user's question contains any of these, offer to run community research:
+- "what MCP servers are people using", "popular MCP servers"
+- "has anyone", "examples", "real-world"
+- "community", "Reddit", "what's trending"
+- "MCP vs skills debate", "should I use MCP or skills"
+
+**When detected**: Answer from reference files first, then offer to run `/research:newsroom` for community perspective.
+
+## Step 1: Classify the Question
+
+Parse the user's question into one or more intent categories. If a question spans multiple categories, identify the primary intent and address it first, then connect to secondary categories.
+
+| Intent | Trigger Signals | Reference File |
+|--------|----------------|----------------|
+| **Setup & Installation** | add MCP, install MCP, connect, remote, HTTP, SSE, stdio, OAuth, Claude Desktop import, popular servers, MCP server list, JSON config, claude mcp add | [setup-and-installation.md](references/setup-and-installation.md) |
+| **Scopes & Configuration** | .mcp.json, local scope, project scope, user scope, precedence, managed-mcp.json, enableAllProjectMcpServers, allowedMcpServers, deniedMcpServers, env var, environment variable, scope hierarchy | [scopes-and-configuration.md](references/scopes-and-configuration.md) |
+| **Tool Search & Scaling** | Tool Search, lazy loading, ENABLE_TOOL_SEARCH, too many tools, context overhead, tool definitions, MCP output limits, MAX_MCP_OUTPUT_TOKENS, MCP_TIMEOUT, MCP_TOOL_TIMEOUT, token cost, accuracy | [tool-search-and-scaling.md](references/tool-search-and-scaling.md) |
+| **MCP in Plugins** | plugin MCP, .mcp.json in plugin, plugin.json mcp, CLAUDE_PLUGIN_ROOT, plugin server, auto-start, plugin MCP troubleshoot | [mcp-in-plugins.md](references/mcp-in-plugins.md) |
+| **Best Practices** | best practice, MCP vs skills, when to use MCP, when to use skills, context cost, response_format, code execution pattern, CLI vs MCP, subagent, architecture, design pattern | [best-practices.md](references/best-practices.md) |
+| **Troubleshooting** | not working, not connecting, error, broken, debug, server not appearing, permission, timeout, output truncated, MCP failed, connection refused, config error | [troubleshooting.md](references/troubleshooting.md) |
+
+## Step 2: Read Reference Files
+
+Read the relevant reference file(s) based on the classification. For multi-intent questions, read all relevant files.
+
+## Step 3: Synthesize Answer
+
+### Response Structure
+
+Every response should follow this structure:
+
+1. **Direct answer** -- one-line answer, no preamble
+2. **Configuration** -- .mcp.json snippets, settings.json configs, or CLI commands (copy-paste ready)
+3. **Why it works** -- brief explanation of the design decision
+4. **Verify step** -- how to confirm it works (`/mcp` menu, `claude mcp list`, etc.)
+5. **Common failure** -- what goes wrong and how to fix
+6. **Source** -- reference file cited
+
+### For Setup Questions
+
+1. Show the exact CLI command or .mcp.json config
+2. Specify transport type (HTTP, SSE, stdio) and when to use each
+3. Include authentication steps if applicable
+4. Show how to verify with `/mcp` or `claude mcp list`
+
+### For Scope/Config Questions
+
+1. Show the config file path and format
+2. Explain precedence (local > project > user)
+3. Show environment variable expansion syntax
+4. Note managed policy implications if relevant
+
+### For Tool Search Questions
+
+1. Explain how lazy loading works (deferred tool definitions)
+2. Show the ENABLE_TOOL_SEARCH configuration options
+3. Provide token cost numbers (before/after)
+4. Note accuracy improvements with citations
+
+### For Plugin MCP Questions
+
+1. Show .mcp.json format in plugin context
+2. Explain auto-start behavior
+3. Show ${CLAUDE_PLUGIN_ROOT} path variable usage
+4. Note the distinction from user/project MCP config
+
+### For Best Practice Questions
+
+1. Use the MCP vs Skills comparison table
+2. Show concrete examples of when each is appropriate
+3. Include the code execution pattern for token efficiency
+4. Reference context cost data
+
+### For Troubleshooting Questions
+
+1. Match symptoms to the troubleshooting table
+2. Provide debug steps in order of likelihood
+3. Include exact commands (`/mcp`, `claude mcp list`, `claude --debug`)
+4. Check config file locations
+
+## Response Guidelines
+
+- **Always cite the reference file** you draw from
+- **Provide copy-paste configs** -- users should be able to use .mcp.json and settings.json snippets immediately
+- **Show CLI commands** -- `claude mcp add` commands for quick setup
+- **Be direct** -- answer first, then context
+- **Tables for comparisons** -- transports, scopes, MCP vs skills
+- **Warn about common mistakes** -- wrong scope, missing env vars, output limits
+- **Link to sibling skills** when the question crosses boundaries (hooks for MCP hooks, skills-guide for skill authoring)
+
+## Examples
+
+### Example 1: Adding an MCP Server
+
+```text
+User: How do I add an MCP server to Claude Code?
+
+Skill: [Reads setup-and-installation.md]
+
+Three transport options:
+
+1. **Remote HTTP** (recommended for hosted servers):
+   claude mcp add my-server --transport http https://api.example.com/mcp
+
+2. **Remote SSE** (legacy streaming):
+   claude mcp add my-server --transport sse https://api.example.com/sse
+
+3. **Local stdio** (local process):
+   claude mcp add my-server -- npx -y @example/mcp-server
+
+Verify: run `/mcp` to see connected servers and their tools.
+
+**Common mistake:** Forgetting `--transport http` for remote servers.
+Default is stdio, which tries to spawn a local process.
+
+Source: setup-and-installation.md
+```
+
+### Example 2: MCP vs Skills
+
+```text
+User: When should I use MCP tools vs skills?
+
+Skill: [Reads best-practices.md]
+
+MCP = tool connectivity (the kitchen). Skills = workflow knowledge (the recipes).
+
+| Use MCP When | Use Skills When |
+|-------------|----------------|
+| Need database access | Need workflow orchestration |
+| Need API integration | Need domain knowledge |
+| High-frequency ops (test runner, linter) | Multi-step processes |
+| Need to control output format/tokens | Need to teach Claude patterns |
+
+**Best together:** MCP server for tool access + skill for workflow guidance.
+Example: Sentry MCP for error data + skill for triage workflow.
+
+The code execution pattern (Anthropic engineering blog) shows
+presenting MCP tools as code APIs rather than direct calls can reduce
+token usage by 98.7%.
+
+Source: best-practices.md
+```
+
+### Example 3: Tool Search / Context Bloat
+
+```text
+User: My MCP servers are using too many tokens
+
+Skill: [Reads tool-search-and-scaling.md]
+
+Tool Search (shipped Claude Code 2.1.7, Jan 2026) auto-defers MCP tool
+definitions when they exceed 10% of context. This reduces overhead
+by 85-95% (from ~51-77K to ~5-8.5K tokens).
+
+Check if it's active:
+- Run `/mcp` to see per-server token costs
+- Run `/context` to see total context usage
+
+Configure:
+  export ENABLE_TOOL_SEARCH=auto:3  # defer when >3 servers (default)
+  export ENABLE_TOOL_SEARCH=true    # always on
+  export ENABLE_TOOL_SEARCH=false   # always off
+
+For MCP server authors: write clear, descriptive tool names and
+descriptions -- Tool Search uses these to find tools at runtime.
+
+Source: tool-search-and-scaling.md
+```
+
+### Example 4: Troubleshooting
+
+```text
+User: My MCP server isn't connecting
+
+Skill: [Reads troubleshooting.md]
+
+Debug steps in order of likelihood:
+
+1. **Check config location** -- run `claude mcp list` to see registered servers.
+   Config lives in:
+   - .mcp.json (project scope)
+   - ~/.claude.json (user scope)
+
+2. **Verify transport** -- HTTP servers need `--transport http`.
+   Without it, Claude tries to spawn a local process.
+
+3. **Check server is running** -- for local stdio servers, ensure the
+   command works standalone: `npx -y @example/mcp-server`
+
+4. **Permission denied** -- first use requires trust verification.
+   Check `/mcp` for pending approvals.
+
+5. **Environment variables** -- .mcp.json supports ${VAR} expansion.
+   Ensure vars are set in your shell profile.
+
+Debug: `claude --debug` shows MCP connection attempts.
+
+Source: troubleshooting.md
+```
+
+### Example 5: Cross-Skill Boundary
+
+```text
+User: How do I add hooks to my MCP server?
+
+Skill: [Detects cross-skill boundary -> hooks domain]
+
+MCP-related hooks are configured in settings.json, not .mcp.json.
+Use PreToolUse/PostToolUse events with matchers targeting MCP tool names.
+
+Quick example -- log all MCP tool calls:
+  {
+    "hooks": {
+      "PostToolUse": [{
+        "matcher": "mcp__.*",
+        "hooks": [{ "type": "command", "command": "echo $TOOL_NAME >> mcp.log" }]
+      }]
+    }
+  }
+
+For full hook configuration, event types, and decision control,
+ask /hooks about hook types and configuration.
+
+Sources: best-practices.md (MCP patterns), hooks skill (hook mechanics)
+```

--- a/plugins/claude-code/skills/mcp-guide/references/best-practices.md
+++ b/plugins/claude-code/skills/mcp-guide/references/best-practices.md
@@ -1,0 +1,174 @@
+# Best Practices
+
+When to use MCP vs skills, context cost management, the code execution pattern, CLI vs MCP trade-offs, and architectural recommendations.
+
+Source: code.claude.com/docs/en/best-practices, code.claude.com/docs/en/costs, anthropic.com/engineering/code-execution-with-mcp, claude.com/blog/extending-claude-capabilities-with-skills-mcp-servers
+
+---
+
+## MCP vs Skills: When to Use Each
+
+MCP = tool connectivity (the kitchen). Skills = workflow knowledge (the recipes).
+
+| Use MCP When | Use Skills When |
+|-------------|----------------|
+| Need to access external APIs/databases | Need to teach Claude a workflow |
+| Need real-time data from services | Need to embed domain knowledge |
+| Tool execution requires specific protocols | Need multi-step orchestration |
+| High-frequency operations (test runner, linter) | Need consistent output format |
+| Need to control server-side output format | Need to guide tool selection |
+| Output varies per query (structured data) | Instructions are the same every time |
+
+### Best Together
+
+The strongest pattern combines both:
+- **MCP server** provides tool access (the "what")
+- **Skill** provides workflow guidance (the "how")
+
+Example:
+- Sentry MCP gives Claude access to error data
+- A triage skill teaches Claude your team's incident workflow
+
+From Anthropic's blog: "MCP servers provide the tool connectivity, skills provide the workflow intelligence. Together, they enable AI-powered automation that's both capable and guided."
+
+---
+
+## The Code Execution Pattern
+
+From Anthropic's engineering blog. Instead of exposing MCP tools directly, present them as code APIs that Claude calls through a code execution environment.
+
+### Why It Works
+
+| Approach | Tokens Used | Token Savings |
+|----------|------------|---------------|
+| Direct MCP tool calls | ~150K tokens | -- |
+| Code execution pattern | ~2K tokens | 98.7% reduction |
+
+### How It Works
+
+1. MCP server provides a code execution environment
+2. Instead of individual tool calls, Claude writes code that uses the APIs
+3. Code runs in the execution environment, results come back
+4. Claude processes the results
+
+### Progressive Disclosure
+
+```
+Level 1: Simple operations  ->  Direct tool calls
+Level 2: Complex workflows  ->  Code execution pattern
+Level 3: Data analysis      ->  Code with library access
+```
+
+### Privacy-Preserving
+
+The code execution pattern keeps sensitive data server-side. Claude writes code that processes data on the server -- raw data never enters the context window.
+
+### State Persistence
+
+Code execution environments persist state across calls. Variables, connections, and intermediate results carry forward within a session.
+
+---
+
+## Context Cost Management
+
+### Check Current Costs
+
+- `/mcp` -- per-server tool counts and token costs
+- `/context` -- total context window breakdown
+
+### Cost Hierarchy
+
+From least to most context-expensive:
+
+1. **CLI tools** (gh, aws, gcloud) -- zero tool definition overhead
+2. **MCP with Tool Search** -- ~5-8.5K tokens for definitions
+3. **MCP without Tool Search** -- ~50-80K+ tokens for definitions
+4. **MCP with large output** -- depends on response size
+
+### Token-Efficient Patterns
+
+**Use `response_format: "json"` for MCP tools:**
+
+```json
+// Skill instructs Claude to use JSON format
+"When calling bun_runTests, always use response_format: 'json' for compact output"
+```
+
+This controls output server-side before it enters the context. Especially valuable for high-frequency tools (test runners, linters) that get called repeatedly.
+
+**Delegate MCP-heavy work to subagents:**
+
+```yaml
+---
+name: my-analysis
+context: fork
+agent: general-purpose
+---
+Use the database MCP tools to analyze the schema and report findings.
+```
+
+MCP tool definitions load in the subagent's context, not the main conversation.
+
+**Use CLI tools when MCP overhead isn't justified:**
+
+| Task | CLI Tool | MCP Alternative | Recommendation |
+|------|---------|----------------|---------------|
+| Git operations | `gh` | GitHub MCP | CLI (zero overhead) |
+| AWS operations | `aws` | AWS MCP | CLI for simple ops |
+| File search | `grep`, `find` | -- | Built-in tools |
+| HTTP requests | `curl` | -- | Built-in WebFetch |
+
+---
+
+## Architectural Recommendations
+
+### Server Count
+
+Community consensus: **2-3 MCP servers + ~12 skills** is the typical power-user sweet spot.
+
+More servers = more context overhead, even with Tool Search. Each server adds:
+- Connection management overhead
+- Tool definition tokens (reduced by Tool Search but not zero)
+- Potential timeout/failure points
+
+### When to Add an MCP Server
+
+Good reasons:
+- Need persistent connection to a service (database, monitoring)
+- Tool needs complex authentication (OAuth)
+- Server provides real-time data
+- High-frequency tool with structured output
+
+Bad reasons:
+- One-off API call (use curl/WebFetch instead)
+- Simple file operations (use built-in tools)
+- Static data (embed in a skill's references/ instead)
+
+### When to Remove an MCP Server
+
+- Haven't used it in the last week
+- CLI alternative works just as well
+- Context budget is tight (check `/context`)
+- Server is unreliable or slow
+
+---
+
+## Security Considerations
+
+### Trust Verification
+
+- First use of a project's MCP servers requires explicit trust approval
+- Review what tools the server exposes before approving
+- Be cautious with servers that can fetch untrusted content (prompt injection risk)
+
+### ToxicSkills Report (Feb 2026)
+
+Security research found that 13.4% of 3,984 public skills had critical vulnerabilities. While focused on skills, the same risks apply to MCP servers:
+- Verify source trustworthiness
+- Review tool permissions
+- Audit server code if possible
+- Prefer well-known, maintained servers
+
+### Principle of Least Privilege
+
+Only connect MCP servers that your workflow actually needs. Each connected server is a potential attack surface.

--- a/plugins/claude-code/skills/mcp-guide/references/mcp-in-plugins.md
+++ b/plugins/claude-code/skills/mcp-guide/references/mcp-in-plugins.md
@@ -1,0 +1,205 @@
+# MCP in Plugins
+
+How to configure MCP servers within Claude Code plugins, auto-start behavior, path variables, and troubleshooting plugin MCP.
+
+Source: code.claude.com/docs/en/plugins-reference, code.claude.com/docs/en/mcp
+
+---
+
+## Overview
+
+Plugins can bundle MCP servers that start automatically when the plugin is enabled. This gives plugins tool access without requiring manual MCP setup.
+
+Two configuration methods:
+1. `.mcp.json` file in the plugin root (recommended)
+2. Inline in `plugin.json` (alternative)
+
+---
+
+## Method 1: .mcp.json in Plugin Root
+
+Create `.mcp.json` alongside `plugin.json`:
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── .mcp.json              # MCP server config
+├── skills/
+│   └── my-skill/
+│       └── SKILL.md
+└── src/
+    └── mcp-server.ts      # Your MCP server code
+```
+
+### .mcp.json Format
+
+```json
+{
+  "mcpServers": {
+    "my-plugin-server": {
+      "command": "bunx",
+      "args": ["--bun", "${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "SOME_CONFIG": "${SOME_ENV_VAR}"
+      }
+    }
+  }
+}
+```
+
+### Path Variable: ${CLAUDE_PLUGIN_ROOT}
+
+Use `${CLAUDE_PLUGIN_ROOT}` to reference files relative to the plugin's installation directory. This resolves to the plugin's root directory at runtime, regardless of where the plugin is installed.
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/server.js"]
+    }
+  }
+}
+```
+
+**Critical:** Always use `${CLAUDE_PLUGIN_ROOT}` for paths. Hardcoded paths break when users install the plugin in different locations.
+
+---
+
+## Method 2: Inline in plugin.json
+
+Add MCP server config directly in `plugin.json`:
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "My plugin with MCP server",
+  "skills": ["./skills/my-skill"],
+  "mcpServers": {
+    "my-server": {
+      "command": "bunx",
+      "args": ["--bun", "${CLAUDE_PLUGIN_ROOT}/dist/index.js"]
+    }
+  }
+}
+```
+
+Both methods work identically. Use `.mcp.json` for consistency with project-level MCP config.
+
+---
+
+## Auto-Start Behavior
+
+Plugin MCP servers start automatically when:
+1. The plugin is enabled in Claude Code
+2. A new Claude Code session starts
+
+Servers stop when:
+1. The plugin is disabled
+2. The Claude Code session ends
+
+### Namespace
+
+Plugin MCP tools are namespaced as `mcp__plugin_{plugin-name}_{server-name}__{tool-name}`:
+
+```
+mcp__plugin_my-plugin_my-server__search_items
+```
+
+This prevents name collisions with user-configured MCP servers.
+
+---
+
+## Plugin MCP vs User MCP
+
+| Aspect | Plugin MCP | User MCP |
+|--------|-----------|----------|
+| Config file | Plugin's `.mcp.json` or `plugin.json` | `~/.claude.json` or project `.mcp.json` |
+| Lifecycle | Auto-start/stop with plugin | Persistent across sessions |
+| Namespace | `mcp__plugin_{name}_{server}__` | `mcp__{server}__` |
+| Trust | Trusted when plugin is approved | Requires individual trust verification |
+| Scope | Where plugin is enabled | User or project scope |
+
+---
+
+## Building MCP Servers for Plugins
+
+### Recommended Stack
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── .mcp.json
+├── src/
+│   ├── index.ts           # MCP server entrypoint
+│   └── tools/
+│       ├── search.ts
+│       └── create.ts
+├── dist/                  # Built output
+│   └── index.js
+└── skills/
+    └── my-skill/
+        └── SKILL.md       # Skill that uses the MCP tools
+```
+
+### Token-Efficient Responses
+
+Control the output format of your MCP server responses:
+
+```typescript
+// Support response_format parameter
+const format = args.response_format ?? 'json';
+if (format === 'json') {
+  return JSON.stringify(result);  // Compact, token-efficient
+} else {
+  return formatAsMarkdown(result);  // Human-readable
+}
+```
+
+This allows skills to request `response_format: "json"` for compact responses that save context tokens.
+
+---
+
+## Troubleshooting Plugin MCP
+
+### Server Not Starting
+
+1. Check the command is valid -- run it manually:
+   ```bash
+   bunx --bun /path/to/plugin/dist/index.js
+   ```
+2. Verify `${CLAUDE_PLUGIN_ROOT}` resolves correctly
+3. Check the plugin is enabled: run `/mcp` to see connected servers
+4. Check for dependency issues: `bun install` in the plugin directory
+
+### Server Not Appearing in /mcp
+
+1. Plugin might not be enabled -- check plugin settings
+2. `.mcp.json` might have syntax errors -- validate JSON
+3. Server name might conflict with an existing server
+
+### Tools Not Being Invoked
+
+1. Check tool names match what the skill references
+2. Verify tools are listed in `/mcp` under the server
+3. If Tool Search is active, ensure tool descriptions are clear enough for discovery
+4. Check `allowed-tools` in the skill's SKILL.md includes the MCP tool names
+
+### Bunx Cache Corruption
+
+If an MCP server fails with module resolution errors:
+
+```
+Cannot find module '@modelcontextprotocol/sdk/server/mcp.js'
+```
+
+Clear the bunx cache:
+
+```bash
+rm -rf /private/var/folders/_b/*/T/bunx-501-@side-quest/
+```
+
+Then restart Claude Code to re-download packages.

--- a/plugins/claude-code/skills/mcp-guide/references/scopes-and-configuration.md
+++ b/plugins/claude-code/skills/mcp-guide/references/scopes-and-configuration.md
@@ -1,0 +1,207 @@
+# Scopes & Configuration
+
+MCP installation scopes, configuration files, precedence rules, environment variables, and managed policies.
+
+Source: code.claude.com/docs/en/mcp, code.claude.com/docs/en/settings
+
+---
+
+## Three Installation Scopes
+
+| Scope | Config File | Applies To |
+|-------|------------|-----------|
+| **Local** | `.claude/settings.local.json` | This machine + this project only |
+| **Project** | `.mcp.json` in project root | Anyone who clones this project |
+| **User** | `~/.claude.json` | All your projects on this machine |
+
+### Local Scope
+
+- Not committed to version control
+- For personal API keys, local development servers
+- Highest precedence -- overrides project and user
+
+### Project Scope
+
+- Committed to version control (`.mcp.json` in project root)
+- Shared with team members
+- Use environment variable expansion for secrets: `${API_KEY}`
+- Team members set their own env vars locally
+
+### User Scope
+
+- Global across all projects
+- For personal productivity servers (calendar, email, notes)
+- Lowest precedence -- overridden by project and local
+
+### Choosing the Right Scope
+
+| Scenario | Scope | Why |
+|----------|-------|-----|
+| Team's shared database | Project | Everyone needs it, same config |
+| Your personal API key | Local | Don't commit secrets |
+| Your calendar server | User | Useful everywhere |
+| CI/CD server | Local | Machine-specific |
+
+---
+
+## Scope Precedence
+
+```
+local > project > user
+```
+
+If the same server name appears in multiple scopes, the most specific scope wins. A local config overrides a project config, which overrides a user config.
+
+---
+
+## Configuration File Formats
+
+### .mcp.json (Project Scope)
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": {
+        "API_KEY": "${API_KEY}",
+        "DATABASE_URL": "${DATABASE_URL}"
+      }
+    },
+    "remote-server": {
+      "type": "http",
+      "url": "https://api.example.com/mcp"
+    }
+  }
+}
+```
+
+### ~/.claude.json (User Scope)
+
+Same `mcpServers` format, but applies globally:
+
+```json
+{
+  "mcpServers": {
+    "my-calendar": {
+      "command": "npx",
+      "args": ["-y", "@example/calendar-mcp"],
+      "env": {
+        "CALENDAR_TOKEN": "${CALENDAR_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Environment Variable Expansion
+
+`.mcp.json` supports `${VAR}` syntax for environment variables:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "node",
+      "args": ["server.js"],
+      "env": {
+        "API_KEY": "${MY_API_KEY}",
+        "DB_URL": "${DATABASE_URL}",
+        "HOME": "${HOME}"
+      }
+    }
+  }
+}
+```
+
+Variables are resolved from the shell environment at Claude Code startup. If a variable is not set, the expansion results in an empty string.
+
+**Tip:** Set variables in your shell profile (`~/.zshrc`, `~/.bashrc`) so they're available when Claude Code starts.
+
+---
+
+## Settings Fields for MCP
+
+These settings control MCP behavior in `settings.json` or `settings.local.json`:
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `enableAllProjectMcpServers` | boolean | Auto-approve all project MCP servers (skip trust prompt) |
+| `enabledMcpjsonServers` | string[] | Specific .mcp.json servers to auto-approve |
+| `disabledMcpjsonServers` | string[] | Specific .mcp.json servers to block |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAX_MCP_OUTPUT_TOKENS` | 25000 | Maximum tokens per MCP tool response |
+| `MCP_TIMEOUT` | 300000 (5 min) | Server initialization timeout (ms) |
+| `MCP_TOOL_TIMEOUT` | 300000 (5 min) | Individual tool call timeout (ms) |
+| `ENABLE_TOOL_SEARCH` | `auto:3` | Tool Search activation threshold |
+
+---
+
+## Managed MCP Configuration
+
+For organizations controlling which MCP servers are allowed.
+
+### Option 1: Exclusive Control (managed-mcp.json)
+
+Place `managed-mcp.json` alongside the Claude Code binary or in a managed settings directory. Servers defined here cannot be modified by users.
+
+```json
+{
+  "mcpServers": {
+    "company-server": {
+      "command": "npx",
+      "args": ["-y", "@company/mcp-server"],
+      "env": {
+        "API_KEY": "${COMPANY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### Option 2: Policy-Based Control (Allowlists/Denylists)
+
+Control which servers users can add:
+
+```json
+{
+  "allowedMcpServers": [
+    "npx -y @company/*",
+    "https://api.company.com/*"
+  ],
+  "deniedMcpServers": [
+    "npx -y @untrusted/*"
+  ]
+}
+```
+
+### Restriction Types
+
+| Type | Match Against | Example |
+|------|-------------|---------|
+| Command-based | The full command string | `"npx -y @company/*"` |
+| URL-based | The server URL | `"https://api.company.com/*"` |
+
+**Allowlist behavior**: If `allowedMcpServers` is set, only matching servers can be added. Everything else is blocked.
+
+**Denylist behavior**: If `deniedMcpServers` is set, matching servers are blocked. Everything else is allowed.
+
+If both are set, a server must match the allowlist AND not match the denylist.
+
+---
+
+## First-Use Trust Verification
+
+When a project `.mcp.json` contains MCP servers, Claude Code prompts for trust verification on first use:
+
+- Each server requires explicit approval
+- Approval is stored locally
+- Use `enableAllProjectMcpServers: true` to skip the prompt
+- Use `enabledMcpjsonServers` to pre-approve specific servers

--- a/plugins/claude-code/skills/mcp-guide/references/setup-and-installation.md
+++ b/plugins/claude-code/skills/mcp-guide/references/setup-and-installation.md
@@ -1,0 +1,234 @@
+# Setup & Installation
+
+How to add MCP servers to Claude Code, transport types, authentication, and importing from other tools.
+
+Source: code.claude.com/docs/en/mcp
+
+---
+
+## What MCP Does
+
+MCP (Model Context Protocol) is an open standard for AI-tool integrations. MCP servers give Claude Code access to external tools, databases, and APIs.
+
+With MCP servers connected, Claude can:
+- Implement features from issue trackers (Jira, Linear)
+- Analyze monitoring data (Sentry, Statsig)
+- Query databases (PostgreSQL, MySQL)
+- Integrate designs (Figma, Slack)
+- Automate workflows (Gmail, calendar)
+
+---
+
+## Transport Types
+
+Three ways to connect an MCP server:
+
+### Remote HTTP (Recommended for hosted servers)
+
+```bash
+claude mcp add my-server --transport http https://api.example.com/mcp
+```
+
+- Modern, recommended transport for remote servers
+- Supports OAuth authentication
+- Most hosted MCP servers use this
+
+### Remote SSE (Legacy streaming)
+
+```bash
+claude mcp add my-server --transport sse https://api.example.com/sse
+```
+
+- Server-Sent Events transport
+- Legacy option, use HTTP when possible
+- Some older servers still require SSE
+
+### Local stdio (Local process)
+
+```bash
+claude mcp add my-server -- npx -y @example/mcp-server
+```
+
+- Spawns a local process
+- Communication via stdin/stdout
+- Default transport if not specified
+- Use for locally-installed servers
+
+**Important:** If connecting to a remote URL, you MUST specify `--transport http` or `--transport sse`. Without it, Claude tries to spawn a local process and fails.
+
+---
+
+## Adding Servers
+
+### CLI Method (Recommended)
+
+```bash
+# Remote HTTP
+claude mcp add circleback --transport http https://app.circleback.ai/api/mcp
+
+# Remote SSE
+claude mcp add my-server --transport sse https://api.example.com/sse
+
+# Local stdio
+claude mcp add my-server -- npx -y @example/mcp-server
+
+# With environment variables
+claude mcp add my-server -e API_KEY=sk-xxx -- npx -y @example/mcp-server
+
+# Specify scope
+claude mcp add my-server --scope user -- npx -y @example/mcp-server
+claude mcp add my-server --scope project -- npx -y @example/mcp-server
+```
+
+### JSON Configuration Method
+
+Create or edit `.mcp.json` in project root:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": {
+        "API_KEY": "${API_KEY}"
+      }
+    }
+  }
+}
+```
+
+For remote servers:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "type": "http",
+      "url": "https://api.example.com/mcp"
+    }
+  }
+}
+```
+
+### Import from Claude Desktop
+
+```bash
+claude mcp add-from-claude-desktop
+```
+
+Imports all MCP servers configured in Claude Desktop. Servers are added to user scope.
+
+---
+
+## Authentication
+
+### OAuth (Remote HTTP/SSE)
+
+Remote MCP servers supporting OAuth will trigger an authentication flow:
+1. Claude Code opens your browser
+2. You authenticate with the service
+3. Token is stored locally
+
+### Pre-configured OAuth
+
+Some servers accept pre-configured credentials:
+
+```bash
+claude mcp add my-server \
+  --transport http \
+  --header "Authorization: Bearer ${MY_TOKEN}" \
+  https://api.example.com/mcp
+```
+
+### API Keys (Local stdio)
+
+Pass API keys as environment variables:
+
+```bash
+claude mcp add my-server -e API_KEY=sk-xxx -- npx -y @example/mcp-server
+```
+
+Or use environment variable expansion in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": {
+        "API_KEY": "${API_KEY}"
+      }
+    }
+  }
+}
+```
+
+The `${API_KEY}` syntax reads from your shell environment at startup.
+
+---
+
+## Managing Servers
+
+| Command | Description |
+|---------|-------------|
+| `claude mcp list` | List all configured servers |
+| `claude mcp remove <name>` | Remove a server |
+| `/mcp` | In-session menu showing connected servers, tools, and token costs |
+| `claude mcp reset` | Remove all MCP servers |
+
+### Dynamic Tool Updates
+
+MCP servers can update their available tools at runtime without restarting Claude Code. When a server's tool list changes, Claude automatically picks up the new tools.
+
+---
+
+## MCP Resources
+
+MCP servers can expose resources (files, data) in addition to tools:
+
+```
+@mcp:server-name/resource-uri
+```
+
+Reference MCP resources in your prompts to provide additional context. Resources are read-only data the server makes available.
+
+---
+
+## MCP Prompts as Commands
+
+MCP servers can provide prompt templates. Execute them with:
+
+```
+/mcp:server-name:prompt-name
+```
+
+These appear in the slash command menu alongside skills and commands.
+
+---
+
+## Using Claude Code as an MCP Server
+
+Claude Code can itself act as an MCP server for other applications:
+
+```bash
+claude mcp serve
+```
+
+This allows other MCP clients to connect to Claude Code and use its capabilities.
+
+---
+
+## Popular MCP Servers
+
+Commonly used servers (install at your own risk -- verify security):
+
+| Server | Purpose | Command |
+|--------|---------|---------|
+| Circleback | Meeting context | `claude mcp add circleback --transport http https://app.circleback.ai/api/mcp` |
+| Sentry | Error monitoring | `claude mcp add sentry --transport http https://mcp.sentry.dev/sse` |
+| GitHub | Code reviews, PRs | Various implementations available |
+| PostgreSQL | Database queries | `claude mcp add postgres -- npx -y @modelcontextprotocol/server-postgres` |
+
+For a full list, see the MCP server directory at modelcontextprotocol.io or the Claude Code documentation.

--- a/plugins/claude-code/skills/mcp-guide/references/tool-search-and-scaling.md
+++ b/plugins/claude-code/skills/mcp-guide/references/tool-search-and-scaling.md
@@ -1,0 +1,158 @@
+# Tool Search & Scaling
+
+How Tool Search (lazy loading) reduces MCP context overhead, configuration options, accuracy data, output limits, and MCP server author guidance.
+
+Source: code.claude.com/docs/en/mcp, code.claude.com/docs/en/costs, code.claude.com/docs/en/settings
+
+---
+
+## The Problem: Context Bloat
+
+Every MCP tool definition is sent in Claude's system prompt. With multiple servers exposing many tools, this can consume 50-80K+ tokens before a conversation even starts.
+
+Example overhead without Tool Search:
+- 3 MCP servers with ~50 tools total: ~51K tokens
+- 5 MCP servers with ~80 tools total: ~77K tokens
+
+This leaves less room for conversation, code, and other context.
+
+---
+
+## Tool Search (Lazy Loading)
+
+Shipped in Claude Code 2.1.7 (January 2026). Automatically defers MCP tool definitions when they would exceed a context threshold.
+
+### How It Works
+
+1. When Tool Search is active, Claude sees only tool **names and descriptions** (not full parameter schemas)
+2. When Claude decides to use a tool, the full definition is loaded on demand
+3. After use, the definition is cached for the session
+4. Reduces token overhead by **85-95%** (from ~51-77K to ~5-8.5K tokens)
+
+### Activation
+
+Tool Search activates automatically when MCP servers exceed a threshold (default: 3 servers or 10% of context window).
+
+### Configuration
+
+```bash
+# Auto mode with custom threshold (default)
+export ENABLE_TOOL_SEARCH=auto:3    # activate when >3 MCP servers
+
+# Always on
+export ENABLE_TOOL_SEARCH=true
+
+# Always off
+export ENABLE_TOOL_SEARCH=false
+
+# Custom auto threshold
+export ENABLE_TOOL_SEARCH=auto:5    # activate when >5 MCP servers
+```
+
+Set in your shell profile (`~/.zshrc`) or in `.claude/settings.local.json`:
+
+```json
+{
+  "env": {
+    "ENABLE_TOOL_SEARCH": "auto:3"
+  }
+}
+```
+
+---
+
+## Accuracy Impact
+
+Tool Search improves accuracy by reducing prompt noise:
+
+| Model | Without Tool Search | With Tool Search | Improvement |
+|-------|-------------------|-----------------|-------------|
+| Opus 4 | 49.0% | 74.0% | +25pp |
+| Opus 4.5 | 79.5% | 88.1% | +8.6pp |
+
+Fewer irrelevant tool definitions means Claude focuses better on the right tools.
+
+---
+
+## MCP Output Limits
+
+### MAX_MCP_OUTPUT_TOKENS
+
+Controls the maximum tokens returned by a single MCP tool call:
+
+```bash
+export MAX_MCP_OUTPUT_TOKENS=25000  # default
+```
+
+When output exceeds this limit:
+- Content is saved to a temporary file
+- Claude receives a pointer to the file instead
+- Claude can read the file if needed
+
+**Recommendation:** Keep the default unless you have a specific need for larger outputs. Large MCP responses consume context rapidly.
+
+### Timeouts
+
+```bash
+export MCP_TIMEOUT=300000       # Server initialization timeout (5 min default)
+export MCP_TOOL_TIMEOUT=300000  # Per-tool-call timeout (5 min default)
+```
+
+---
+
+## For MCP Server Authors
+
+When Tool Search is active, Claude decides which tools to load based on names and descriptions alone. To maximize discoverability:
+
+1. **Use clear, descriptive tool names** -- `search_issues` not `s_iss`
+2. **Write detailed descriptions** -- explain what the tool does and when to use it
+3. **Group related tools** -- consistent naming prefix helps (`github_list_prs`, `github_create_pr`)
+4. **Keep parameter schemas simple** -- fewer required params = easier discovery
+5. **Return structured, compact results** -- don't dump raw data; format for consumption
+
+### Output Token Efficiency
+
+Design your server responses to be token-efficient:
+- Return structured JSON, not raw dumps
+- Include summary fields alongside detail
+- Support pagination for large result sets
+- Offer format options (e.g., `response_format: "json"` vs `"markdown"`)
+
+---
+
+## Monitoring Context Costs
+
+### Check per-server costs
+
+Run `/mcp` in Claude Code to see:
+- Connected servers and their status
+- Number of tools per server
+- Token cost of tool definitions
+
+### Check total context usage
+
+Run `/context` to see:
+- Total context window usage
+- Breakdown by category (system prompt, tools, conversation, etc.)
+- Warnings about excluded skills or tools
+
+### Cost Reduction Strategies
+
+1. **Enable Tool Search** -- automatic 85-95% reduction in tool definition overhead
+2. **Remove unused servers** -- `claude mcp remove <name>`
+3. **Use CLI tools instead** -- `gh`, `aws`, `gcloud` are more context-efficient than MCP equivalents for simple operations
+4. **Control output format** -- servers supporting `response_format: "json"` return compact data
+5. **Use subagents** -- delegate MCP-heavy work to subagents so tool definitions don't pollute the main context
+
+---
+
+## Scaling Recommendations
+
+| Server Count | Recommendation |
+|-------------|---------------|
+| 1-3 servers | Tool Search optional, low overhead |
+| 3-5 servers | Tool Search auto-activates (default threshold) |
+| 5-10 servers | Tool Search essential, monitor with /context |
+| 10+ servers | Consider removing rarely-used servers, use subagent delegation |
+
+The community consensus is ~2-3 MCP servers + ~12 skills as a typical power-user setup. More MCP servers than this should trigger a review of whether all are needed.

--- a/plugins/claude-code/skills/mcp-guide/references/troubleshooting.md
+++ b/plugins/claude-code/skills/mcp-guide/references/troubleshooting.md
@@ -1,0 +1,197 @@
+# Troubleshooting
+
+Common MCP problems, debug steps, error messages, and solutions.
+
+Source: code.claude.com/docs/en/troubleshooting, code.claude.com/docs/en/mcp
+
+---
+
+## Quick Reference
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Server not connecting | Wrong transport type | Add `--transport http` for remote URLs |
+| Server not appearing in /mcp | Config file error | Validate JSON syntax in .mcp.json |
+| Tools not found | Tool Search hiding them | Check `/mcp` for tool list, verify descriptions |
+| Output truncated | MAX_MCP_OUTPUT_TOKENS limit | Increase limit or design responses to be compact |
+| Timeout errors | Slow server or network | Increase MCP_TIMEOUT / MCP_TOOL_TIMEOUT |
+| Permission denied | First-use trust check | Approve server in the trust prompt |
+| "Cannot find module" | Bunx cache corruption | Clear bunx cache, restart Claude Code |
+| Server crashes on start | Bad command or missing deps | Run command manually to debug |
+| Env vars not expanding | Not set in shell profile | Add to ~/.zshrc and restart terminal |
+| Wrong scope applying | Precedence order | Check local > project > user priority |
+
+---
+
+## Debug Steps
+
+### Step 1: Check Server Status
+
+```
+/mcp
+```
+
+Shows all connected servers, their status, tool count, and token cost. If your server isn't listed, the config isn't being read.
+
+### Step 2: List Registered Servers
+
+```bash
+claude mcp list
+```
+
+Shows all configured servers across all scopes (local, project, user). If the server is listed but not connected, it's a startup issue.
+
+### Step 3: Enable Debug Mode
+
+```bash
+claude --debug
+```
+
+Shows detailed logs including:
+- MCP connection attempts
+- Server startup output
+- Tool discovery
+- Error messages
+
+### Step 4: Check Config Files
+
+Configs are read from (in precedence order):
+
+1. `.claude/settings.local.json` (local scope)
+2. `.mcp.json` in project root (project scope)
+3. `~/.claude.json` (user scope)
+
+Validate JSON syntax:
+```bash
+python3 -m json.tool .mcp.json
+python3 -m json.tool ~/.claude.json
+```
+
+---
+
+## Common Errors
+
+### "Connection refused" or Server Not Starting
+
+**For remote servers:**
+1. Verify the URL is correct and accessible
+2. Ensure you specified the transport: `--transport http` or `--transport sse`
+3. Check if authentication is required (OAuth flow might be needed)
+4. Test the URL directly: `curl https://api.example.com/mcp`
+
+**For local stdio servers:**
+1. Run the command manually to verify it works:
+   ```bash
+   npx -y @example/mcp-server
+   ```
+2. Check dependencies are installed
+3. Check file permissions: `chmod +x ./my-server.sh`
+4. Verify Node.js/Bun is available
+
+### "Cannot find module" Errors
+
+Usually bunx cache corruption. Clear and retry:
+
+```bash
+# Find and remove corrupted cache
+rm -rf /private/var/folders/_b/*/T/bunx-501-@side-quest/
+
+# For other packages
+rm -rf /private/var/folders/_b/*/T/bunx-501-@example/
+```
+
+Then restart Claude Code.
+
+### Environment Variables Not Expanding
+
+`.mcp.json` uses `${VAR}` syntax. If values are empty:
+
+1. Check the variable is set: `echo $MY_API_KEY`
+2. Ensure it's in your shell profile (`~/.zshrc`), not just the current session
+3. Restart Claude Code after adding to shell profile
+4. Note: `.env` files are NOT automatically read by Claude Code
+
+### Output Truncated or "Output saved to file"
+
+MCP tool output exceeds `MAX_MCP_OUTPUT_TOKENS` (default: 25000).
+
+Options:
+1. Increase the limit: `export MAX_MCP_OUTPUT_TOKENS=50000`
+2. Design your server to return compact responses
+3. Support `response_format: "json"` for token-efficient output
+4. Add pagination to large result sets
+
+### Timeout Errors
+
+Default timeouts are 5 minutes each. If your server needs more time:
+
+```bash
+export MCP_TIMEOUT=600000        # 10 min server init
+export MCP_TOOL_TIMEOUT=600000   # 10 min per tool call
+```
+
+### Server Conflicts
+
+If two servers have the same name, the higher-precedence scope wins (local > project > user). To resolve:
+
+1. Check all config files for duplicate names
+2. Rename one server
+3. Or remove the lower-priority duplicate
+
+### MCP Server Not Auto-Invoking
+
+If Claude doesn't use your MCP tools when expected:
+
+1. **Tool Search might be hiding tools** -- check `/mcp` to verify tools are listed
+2. **Tool descriptions might be unclear** -- Tool Search uses descriptions to find tools
+3. **Wrong tool name in prompt** -- verify exact tool names in `/mcp`
+4. **Too many tools** -- Claude might be overwhelmed. Consider reducing server count.
+
+---
+
+## Plugin MCP Issues
+
+### Plugin Server Not Starting
+
+1. Verify the plugin is enabled
+2. Check `${CLAUDE_PLUGIN_ROOT}` resolves: the path should point to the plugin directory
+3. Run the server command manually with the resolved path
+4. Check plugin logs for errors
+
+### Plugin Tool Names
+
+Plugin MCP tools are namespaced:
+```
+mcp__plugin_{plugin-name}_{server-name}__{tool-name}
+```
+
+When referencing in skills, use the full namespaced name.
+
+---
+
+## Performance Issues
+
+### High Token Usage from MCP
+
+1. Run `/context` to check total usage
+2. Run `/mcp` to see per-server costs
+3. Enable Tool Search: `export ENABLE_TOOL_SEARCH=true`
+4. Remove servers you're not actively using
+5. Use CLI alternatives for simple operations
+
+### Slow MCP Responses
+
+1. Check server-side performance
+2. Increase timeouts if needed
+3. Consider caching strategies in your server
+4. Use `async: true` for hooks on MCP tool calls to avoid blocking
+
+---
+
+## Getting Help
+
+- `claude --debug` for verbose logging
+- `/mcp` for server status and tool inventory
+- `/context` for context window breakdown
+- `claude mcp list` for all registered servers
+- `/hooks` for MCP-related hook configuration


### PR DESCRIPTION
## Summary

- Add `mcp-guide` knowledge bank skill to the `claude-code` plugin
- Covers MCP server setup, configuration scopes, Tool Search/lazy loading, plugin MCP integration, best practices (MCP vs skills), and troubleshooting
- Synthesized from 11 official Anthropic documentation pages and engineering blog posts
- Follows the same classify-read-synthesize pattern as the existing `hooks` and `skills-guide` skills

## Files

```
plugins/claude-code/skills/mcp-guide/
├── SKILL.md                              (259 lines)
└── references/
    ├── setup-and-installation.md          (234 lines) - transports, CLI, OAuth, popular servers
    ├── scopes-and-configuration.md        (207 lines) - local/project/user, precedence, env vars
    ├── tool-search-and-scaling.md         (158 lines) - lazy loading, accuracy data, output limits
    ├── mcp-in-plugins.md                  (205 lines) - plugin .mcp.json, CLAUDE_PLUGIN_ROOT
    ├── best-practices.md                  (174 lines) - MCP vs skills, code execution pattern
    └── troubleshooting.md                 (197 lines) - debug steps, common errors
```

## Test plan

- [ ] Invoke `/mcp-guide how do I add an MCP server?` -- should route to setup-and-installation.md
- [ ] Ask "My MCP server isn't connecting" -- should auto-trigger and route to troubleshooting.md
- [ ] Ask "When should I use MCP vs skills?" -- should route to best-practices.md
- [ ] Ask "How do I write a skill?" -- should NOT trigger mcp-guide (should trigger skills-guide)
- [ ] Verify all 6 reference files are readable and correctly linked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Model Context Protocol (MCP) guidance including setup, configuration, best practices, and troubleshooting documentation
  * Introduced detailed reference materials for MCP integration, scopes management, and tool search optimization

* **Chores**
  * Updated plugin metadata to reflect MCP-related functionality and resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->