### PR TITLE
docs(bun-typescript-starter): add required_conversation_resolution to setup-protect docs

### DIFF
--- a/plugins/bun-typescript-starter/references/setup-script.md
+++ b/plugins/bun-typescript-starter/references/setup-script.md
@@ -43,10 +43,11 @@ When enabled, the setup script:
 
 1. **Workflow permissions**: Sets `default_workflow_permissions=write` and `can_approve_pull_request_reviews=true`
 2. **Merge settings**: Squash merge only, auto-delete branches, allow auto-merge
-3. **Branch protection** on `main`:
+3. **Branch protection** on `main` (via `bun run setup:protect`):
    - Required status check: "All checks passed"
    - Strict up-to-date requirement
    - Dismiss stale reviews
+   - Required conversation resolution before merging
    - Required linear history
    - No force pushes or deletions
    - Enforce for admins


### PR DESCRIPTION
## Summary

- Add missing `required_conversation_resolution` to the branch protection checklist in setup-script.md
- The `setup-protect.ts` script already sets this, but the reference doc omitted it

## Test plan

- [x] Verified `setup-protect.ts` already includes `required_conversation_resolution: true`
- [x] Doc now matches actual script behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup documentation to reflect branch protection requirements, including required conversation resolution before merging on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->