### PR TITLE
docs(marketplace): add curated starter packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Add the marketplace and install plugins:
 | **enterprise** | development | Multi-agent engineering orchestrator with Star Trek metaphor. Spock coordinates Scotty (builder) and McCoy (validator) for documentation, code review, and refactoring. 9 commands, 8 skills, 3 agents. |
 | **newsroom** | productivity | Multi-agent research across Reddit, X, and the web. Mickey "The Desk" Malone dispatches beat reporters in parallel with engagement metrics and source links. 2 commands, 2 skills, 1 agent. |
 
+## Starter Packs (V1.1)
+
+Starter packs group related plugins for common workflows. Each plugin installs independently -- packs are a discovery shortcut, not a bundle.
+
+| Pack | Plugins | Description |
+|------|---------|-------------|
+| **quality-gates** | bun-runner, tsc-runner, biome-runner | Lint, type-check, and test your code |
+| **compound-engineering** | git, enterprise, newsroom | Full CE stack -- safety, orchestration, research |
+| **code-intelligence** | kit, claude-code | Semantic search, navigation, Claude Code knowledge |
+
+Install a pack by installing each plugin:
+
+```bash
+# Quality Gates
+/plugin install bun-runner@side-quest
+/plugin install tsc-runner@side-quest
+/plugin install biome-runner@side-quest
+```
+
 ## Migrating from Symlinks
 
 If you previously installed plugins via `ln -s`:

--- a/docs/plans/2026-02-21-feat-v1-curated-marketplace-plan.md
+++ b/docs/plans/2026-02-21-feat-v1-curated-marketplace-plan.md
@@ -317,6 +317,38 @@ Use the official Anthropic category values as `category` (for discoverability), 
 
 ---
 
+## Starter Packs
+
+### Concept
+
+Starter packs are recommended groupings of related plugins for common workflows. Each plugin installs independently -- packs are a discovery shortcut, not a bundle. They solve the "which plugins should I install together?" problem as the catalog grows past 10-15 plugins.
+
+### Why Not in marketplace.json?
+
+The marketplace.json schema does NOT support custom fields like `collections`. Root-level fields are limited to `name`, `version`, `description`, `owner`, `metadata`, and `plugins`. Adding unknown fields may break `claude plugin validate .`. Therefore, starter packs are a **documentation-layer concept** -- README sections, plan docs, and optional project settings files -- not a schema extension.
+
+### Initial Starter Packs (V1.1+)
+
+| Pack | Description | Plugins |
+|------|-------------|---------|
+| **quality-gates** | Lint, type-check, and test your code | bun-runner, tsc-runner, biome-runner |
+| **compound-engineering** | The full CE stack -- safety, orchestration, research | git, enterprise, newsroom |
+| **code-intelligence** | Semantic search, navigation, and Claude Code knowledge | kit, claude-code |
+
+These packs will be defined once enough plugins exist to form meaningful groups (V1.1+, when quality-gates and code-intelligence plugins pass the acceptance checklist).
+
+### Delivery Mechanisms
+
+1. **README section** with grouped install commands (human discovery). Users see which plugins go together and can copy-paste install commands for an entire pack.
+
+2. **Example project settings files** in `starter-packs/` directory -- `.claude/settings.json` snippets with `enabledPlugins` pre-configured that teams can copy into their projects (agent + team discovery). Each file is a ready-to-use settings fragment.
+
+### Timing
+
+V1.1+ -- when enough plugins exist to form meaningful groups. The compound-engineering pack can be documented immediately (all 3 plugins are V1), but quality-gates and code-intelligence packs require their constituent plugins to pass the acceptance checklist first.
+
+---
+
 ## Acceptance Criteria
 
 ### Marketplace-Level (V1 release gate)
@@ -592,6 +624,8 @@ This phase creates the marketplace shell with all 3 V1 plugins, fixes manifest i
 - `CONTRIBUTING.md` for external contributors
 - Plugin versioning strategy
 - Auto-update configuration
+- `starter-packs/` directory with example `.claude/settings.json` files for each pack
+- File a Claude Code feature request for native `collections` in marketplace.json schema and batch install command
 
 ### V3: Advanced
 - `/marketplace:verify <plugin-path>` command (agent-automated acceptance checks)

--- a/docs/plugin-standards.md
+++ b/docs/plugin-standards.md
@@ -49,6 +49,28 @@ When a plugin spans multiple categories, assign the category that best describes
 
 ---
 
+## Starter Packs
+
+Starter packs are recommended groupings of related plugins for common workflows. They help users discover which plugins work well together without coupling the packages.
+
+Starter packs exist in documentation (README) and as example project settings files -- not in marketplace.json. The marketplace schema does not support custom fields like `collections`, and adding unknown fields may break validation.
+
+**Rules:**
+
+- A plugin can appear in multiple starter packs.
+- Naming convention: kebab-case, descriptive of the workflow (e.g., `quality-gates` not `bun-biome-tsc`).
+- Each pack needs: name, description (one sentence), list of plugin names, install commands.
+
+**Current packs:**
+
+| Pack | Description | Plugins |
+|------|-------------|---------|
+| **quality-gates** | Lint, type-check, and test your code | bun-runner, tsc-runner, biome-runner |
+| **compound-engineering** | The full CE stack -- safety, orchestration, research | git, enterprise, newsroom |
+| **code-intelligence** | Semantic search, navigation, and Claude Code knowledge | kit, claude-code |
+
+---
+
 ## Multi-Agent Plugin Requirements
 
 Plugins that coordinate multiple sub-agents carry additional cost and complexity that users must be able to reason about before installing. Any plugin that spawns, orchestrates, or delegates work to sub-agents must document the following in its README.


### PR DESCRIPTION
## Summary

- Define three starter packs (quality-gates, compound-engineering, code-intelligence) as a documentation-layer concept
- Add Starter Packs section to the V1 marketplace plan, plugin-standards.md, and README.md
- Add V2 scope bullets for `starter-packs/` directory and Claude Code feature request for native `collections` support

Starter packs are NOT in marketplace.json -- the schema doesn't support custom fields and unknown fields may break `claude plugin validate .`. Instead they live in docs and (V2) example project settings files.

## Test plan

- [x] Confirm marketplace.json is NOT modified
- [x] All 51 tests pass
- [x] Starter pack tables are consistent across all 3 files
- [x] V2 scope bullets added to plan doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Starter Packs (V1.1)** introduced: Three curated plugin groupings for common workflows:
  * Quality Gates: Lint, type-check, and test code
  * Compound Engineering: Full CE stack with safety and orchestration
  * Code Intelligence: Semantic search and navigation
* Added installation guidance for starter packs
* Enhanced standards documentation with starter packs and multi-agent plugin coordination patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->