### PR TITLE
feat(marketplace): add observability plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://code.claude.com/docs/en/plugin-marketplaces",
 	"name": "side-quest",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Curated, verified Claude Code plugins for compound engineering workflows",
 	"owner": {
 		"name": "Nathan Vale",
@@ -62,6 +62,13 @@
 				"agent-teams",
 				"compound-engineering"
 			]
+		},
+		{
+			"name": "observability",
+			"source": "./plugins/observability",
+			"description": "Real-time event streaming from Claude Code sessions to @side-quest/observability server",
+			"category": "development",
+			"tags": ["observability", "events", "telemetry", "lifecycle", "hooks"]
 		}
 	]
 }

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,169 +1,127 @@
-# bun-typescript-starter
+# CLAUDE.md
 
-A production-ready TypeScript/Bun project template with CI/CD, linting, testing, and publishing infrastructure.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Stack:** TypeScript, Bun, Biome, Vitest, Changesets
+## What This Is
 
----
+A Claude Code plugin marketplace -- a monorepo of plugins that extend Claude Code with skills, commands, agents, and hooks. Each plugin lives under `plugins/<name>/` and is registered in `.claude-plugin/marketplace.json`.
 
-## Quick Start
-
-```bash
-# After "Use this template" on GitHub
-bun run setup    # Interactive configuration
-bun install      # Install dependencies (if not done by setup)
-bun dev          # Watch mode development
-bun test         # Run tests
-bun run build    # Build for production
-```
-
----
-
-## Key Commands
+## Commands
 
 ```bash
-# Development
-bun dev                  # Watch mode
-bun build                # Build TypeScript to dist/
-
-# Quality
-bun run check            # Biome lint + format (write mode)
-bun typecheck            # TypeScript type checking
-bun run validate         # Full quality check (lint + types + build + test)
-
-# Testing
-bun test                 # Run all tests
-bun test --coverage      # With coverage report
-
-# Releases
-bun version:gen          # Create changeset
+bun run check              # Biome lint + format (write mode)
+bun run typecheck          # TypeScript type checking (tsc --noEmit)
+bun run validate:marketplace  # Marketplace structure validation
+bun run validate           # Full gate: check + typecheck + marketplace validation
+bun run lint               # Biome lint only (no auto-fix)
+bun run lint:fix           # Biome lint with auto-fix
+bun run format             # Biome format with write
+bun run format:check       # Biome format check only
 ```
 
----
+Always run `bun run validate` before pushing.
 
-## Code Conventions
+## Architecture
 
-| Area | Convention |
-|------|------------|
-| Files | kebab-case (`my-util.ts`) |
-| Functions | camelCase (`doSomething`) |
-| Types | PascalCase (`MyType`) |
-| Exports | Named only (no defaults) |
-| Formatting | Biome (tabs, single quotes, 80-char) |
+### Plugin Anatomy
 
----
-
-## Git Workflow
-
-**Branch pattern:** `type/description` (e.g., `feat/add-feature`, `fix/bug-fix`)
-
-**Commit format:** Conventional Commits (enforced by commitlint)
+Every plugin requires this minimum structure:
 
 ```
-feat(scope): add new feature
-fix(scope): fix bug
-chore(deps): update dependencies
+plugins/<name>/
+  .claude-plugin/
+    plugin.json        # Manifest (name, version, commands, skills, agents)
+  README.md            # Required -- see docs/plugin-standards.md for template
 ```
 
-**Before pushing:** Always run `bun run validate`
+Optional components:
 
----
+- `commands/*.md` -- slash commands (YAML frontmatter + markdown body)
+- `skills/<skill-name>/SKILL.md` -- auto-activated skills (YAML frontmatter + markdown)
+- `skills/<skill-name>/references/` -- conditional context loaded by flag/mode/tool detection
+- `agents/*.md` -- sub-agent definitions for multi-agent plugins
+- `hooks/hooks.json` -- lifecycle hook config (SessionStart, PreToolUse, PostToolUse, PreCompact, Stop)
+- `hooks/*.ts` -- TypeScript hook implementations (run via `bun run`)
 
-## Template Development Workflow
+### Marketplace Registry
 
-When dogfooding this template (testing it in a real project), use this workflow to push fixes back upstream.
+`.claude-plugin/marketplace.json` is the source of truth for available plugins. Each entry needs:
 
-### Setup (one-time)
-
-```bash
-# Create a new repo from template via GitHub UI
-# Clone it locally
-git clone git@github.com:youruser/your-new-project.git
-cd your-new-project
-
-# Add template as upstream remote
-git remote add template git@github.com:nathanvale/bun-typescript-starter.git
+```json
+{
+  "name": "my-plugin",
+  "source": "./plugins/my-plugin",
+  "description": "What it does in one sentence",
+  "category": "development|productivity|security|learning",
+  "tags": ["relevant", "tags"]
+}
 ```
 
-### Pushing Fixes Upstream
+The validation script (`scripts/validate-marketplace.ts`) enforces:
+- Kebab-case names matching the source directory basename
+- Source paths resolve to a directory containing `.claude-plugin/plugin.json`
+- No duplicate names
+- Valid category enum
+- Version bump enforcement on PRs (minor for additions, major for removals, patch for metadata changes)
 
-When you find an issue in the template while using it:
+### Plugin Manifest
 
-```bash
-# 1. Fix the issue in your dogfood project
-# 2. Commit the fix
-git add .
-git commit -m "fix: description of the fix"
+`.claude-plugin/plugin.json` inside each plugin:
 
-# 3. Push to your project's origin (optional, for your project)
-git push origin main
-
-# 4. Push to template upstream
-git push template HEAD:main
+```json
+{
+  "name": "my-plugin",
+  "description": "One sentence, present tense, no trailing period",
+  "version": "1.0.0",
+  "author": { "name": "Nathan Vale" },
+  "keywords": ["search", "terms"],
+  "license": "MIT",
+  "commands": ["./commands/my-command.md"],
+  "skills": ["./skills/my-skill"],
+  "agents": ["./agents/my-agent.md"]
+}
 ```
 
-### Pulling Template Updates
+All paths are relative to the plugin root and validated by `claude plugin validate .`.
 
-```bash
-# Fetch latest from template
-git fetch template
+### Progressive Disclosure Pattern
 
-# Merge template changes into your project
-git merge template/main --allow-unrelated-histories
+Skills use a references/ subdirectory for conditional context loading. The main SKILL.md is always loaded (~2,000 tokens). References are loaded only when relevant flags, modes, or tools are detected. This keeps default token cost low.
+
+### Hook Config
+
+`hooks/hooks.json` maps lifecycle events to commands:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/my-hook.ts\"", "timeout": 5 }] }]
+  }
+}
 ```
 
----
+Available events: `SessionStart`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `Stop`
 
-## Publishing
+## Conventions
 
-This template uses **OIDC Trusted Publishing** for npm releases.
+- **Files:** kebab-case (`my-plugin.ts`)
+- **Functions:** camelCase
+- **Types:** PascalCase
+- **Exports:** named only (no defaults)
+- **Formatting:** Biome -- tabs, single quotes, 80-char line width
+- **Single biome.json at root** -- NEVER create nested configs
+- **Commits:** Conventional Commits (`feat(scope): subject`)
+- **Branches:** `type/description` (e.g., `feat/add-observability`)
+- **Hook TypeScript:** always include a self-destruct timer as the first executable line for safety
 
-### First Publish (requires NPM_TOKEN)
+## Rules
 
-1. Add `NPM_TOKEN` secret to GitHub repo settings
-2. Create a changeset: `bun version:gen`
-3. Push to main, merge the "Version Packages" PR
+Context-specific rules live in `.claude/rules/`:
 
-### After First Publish (OIDC)
+- `add-plugin.md` -- step-by-step checklist for adding a new plugin to the marketplace
 
-1. Configure trusted publisher at: https://www.npmjs.com/package/YOUR_PACKAGE/access
-2. Remove `NPM_TOKEN` secret (no longer needed)
-3. Future publishes authenticate via GitHub OIDC
+## Key References
 
----
-
-## CI/CD Workflows
-
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `pr-quality.yml` | PR | Lint, types, tests |
-| `publish.yml` | Push to main | Version & publish |
-| `commitlint.yml` | PR | Validate commit messages |
-| `security.yml` | Schedule/PR | CodeQL + Trivy scans |
-
----
-
-## Customization
-
-After running `bun run setup`:
-
-1. **Add source files** in `src/`
-2. **Add tests** alongside source (`*.test.ts`)
-3. **Update exports** in `bunup.config.ts`
-4. **Configure path aliases** in `tsconfig.json` if needed
-
----
-
-## Special Rules
-
-### ALWAYS
-
-1. Run `bun run validate` before pushing
-2. Create changesets for user-facing changes
-3. Use named exports (no defaults)
-
-### NEVER
-
-1. Push directly to main (pre-push hook blocks)
-2. Skip validation before commits
-3. Use destructive git commands (`reset --hard`, `push --force`)
+- `docs/plugin-standards.md` -- full acceptance checklist, category system, multi-agent requirements, README template, versioning policy
+- `FOR_NATHAN.md` -- architectural narrative explaining design decisions and patterns
+- `scripts/validate-marketplace.ts` -- marketplace validation logic

--- a/.claude/rules/add-plugin.md
+++ b/.claude/rules/add-plugin.md
@@ -1,0 +1,107 @@
+---
+description: Checklist for adding a new plugin to the marketplace
+globs: plugins/**/*
+---
+
+# Add a Plugin -- Step-by-Step Checklist
+
+## 1. Create the plugin directory
+
+```
+plugins/<name>/
+  .claude-plugin/
+    plugin.json
+  README.md
+```
+
+The directory name MUST be kebab-case and match the `name` field in plugin.json.
+
+## 2. Write the plugin manifest
+
+Create `.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "<name>",
+  "description": "One sentence, present tense, no trailing period",
+  "version": "1.0.0",
+  "author": { "name": "Nathan Vale" },
+  "keywords": ["relevant", "keywords"],
+  "license": "MIT",
+  "commands": [],
+  "skills": []
+}
+```
+
+Populate `commands`, `skills`, and `agents` arrays with relative paths as you add components.
+
+## 3. Add plugin components
+
+Add whichever components the plugin needs:
+
+- **Commands:** `commands/<name>.md` with YAML frontmatter (description, model, allowed-tools, skill)
+- **Skills:** `skills/<name>/SKILL.md` with YAML frontmatter (name, description, allowed-tools, use-when)
+- **Agents:** `agents/<name>.md` with YAML frontmatter (model, tools) -- for multi-agent plugins
+- **Hooks:** `hooks/hooks.json` + `hooks/<name>.ts` -- for lifecycle event handlers
+
+Every path listed in plugin.json must resolve to a real file or directory.
+
+## 4. Write the README
+
+Follow the template in `docs/plugin-standards.md`. Minimum sections:
+
+1. Title + one-paragraph description
+2. Install (`/plugin install <name>@side-quest`)
+3. Usage (show command examples)
+4. Requirements (external deps)
+5. Limitations
+
+Multi-agent plugins also need: How It Works (coordination pattern, agent roles, compute multiplier, safety).
+
+## 5. Register in marketplace.json
+
+Add an entry to `.claude-plugin/marketplace.json` in the `plugins` array:
+
+```json
+{
+  "name": "<name>",
+  "source": "./plugins/<name>",
+  "description": "Short description for marketplace listing",
+  "category": "development|productivity|security|learning",
+  "tags": ["tag1", "tag2"]
+}
+```
+
+## 6. Bump the marketplace version
+
+In `.claude-plugin/marketplace.json`, bump the root `version` field:
+
+- Adding a plugin = **minor** bump (e.g., 1.1.0 -> 1.2.0)
+- Removing a plugin = **major** bump
+- Changing metadata only = **patch** bump
+
+## 7. Validate
+
+Run all three validation steps:
+
+```bash
+bun run validate                    # Biome + TypeScript + marketplace structure
+cd plugins/<name> && claude plugin validate .   # Claude Code plugin validation
+```
+
+Both must pass with zero errors.
+
+## 8. Test end-to-end
+
+Install the plugin and verify at least one command or skill works:
+
+```bash
+/plugin install <name>@side-quest
+/<name>:<command>
+```
+
+## 9. Commit and PR
+
+- Branch: `feat/add-<name>-plugin` or `feat/<name>`
+- Commit: `feat(marketplace): add <name> plugin`
+- PR description: what the plugin does + which demo flow to run

--- a/plugins/observability/.claude-plugin/plugin.json
+++ b/plugins/observability/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+	"name": "observability",
+	"description": "Real-time observability -- streams Claude Code lifecycle events to @side-quest/observability server",
+	"version": "0.1.0",
+	"author": { "name": "Nathan Vale" },
+	"keywords": ["observability", "events", "telemetry", "lifecycle", "hooks"],
+	"license": "MIT"
+}

--- a/plugins/observability/README.md
+++ b/plugins/observability/README.md
@@ -1,0 +1,48 @@
+# Observability
+
+Real-time observability for Claude Code sessions. Streams lifecycle events (session start, tool use, tool failure, session stop) to the `@side-quest/observability` server via fire-and-forget HTTP POSTs. The hook is a dumb pipe -- all event enrichment happens server-side.
+
+## Install
+
+```bash
+/plugin install observability@side-quest
+```
+
+## How It Works
+
+A single TypeScript hook (`emit-event.ts`) handles all 5 lifecycle events. On each event, it:
+
+1. Reads the JSON payload from stdin
+2. Discovers the observability server port from `~/.cache/side-quest-observability/events.port`
+3. POSTs the raw JSON to `http://127.0.0.1:<port>/events/<event-name>`
+4. Exits (500ms network timeout, 4.5s self-destruct timer)
+
+If the server is not running, the hook fails silently. It never blocks Claude Code.
+
+### Lifecycle Events
+
+| Event | Sync/Async | When |
+|-------|-----------|------|
+| `session-start` | sync | Session begins |
+| `pre-tool-use` | async | Before any tool executes |
+| `post-tool-use` | async | After any tool executes |
+| `post-tool-use-failure` | async | After a tool fails |
+| `stop` | sync | Session ends |
+
+### Environment Variables
+
+| Variable | Effect |
+|----------|--------|
+| `SIDE_QUEST_EVENTS=0` | Kill switch -- disables all event emission |
+| `SIDE_QUEST_HOOK_DEBUG=1` | Logs network errors to stderr |
+
+## Requirements
+
+- **Bun runtime** -- hooks run via `bun run`
+- **@side-quest/observability server** -- must be running and writing its port to `~/.cache/side-quest-observability/events.port`
+
+## Limitations
+
+- Fire-and-forget only -- no delivery guarantees, no retry, no buffering
+- Server discovery via port file -- if the file is stale or missing, events are silently dropped
+- 1MB payload cap -- events larger than 1MB are dropped (OOM protection)

--- a/plugins/observability/hooks/emit-event.ts
+++ b/plugins/observability/hooks/emit-event.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env bun
+
+/**
+ * Observability hook -- dumb pipe.
+ *
+ * Reads Claude Code's stdin JSON, POSTs it raw to the observability server,
+ * and exits. All event enrichment (type mapping, payload extraction, envelope
+ * generation) happens server-side.
+ *
+ * Zero external dependencies. Marketplace-compatible.
+ *
+ * Usage: echo '{"session_id":"..."}' | bun run emit-event.ts session-start
+ */
+
+// Self-destruct timer: MUST be first executable line.
+// Claude Code may not enforce timeouts on async hooks (issue #25700).
+const selfDestruct = setTimeout(() => process.exit(0), 4500)
+
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const PORT_FILE = join(
+	homedir(),
+	'.cache',
+	'side-quest-observability',
+	'events.port',
+)
+const TIMEOUT_MS = 500
+const DEBUG = process.env.SIDE_QUEST_HOOK_DEBUG === '1'
+
+async function main(): Promise<void> {
+	// Kill switch
+	if (process.env.SIDE_QUEST_EVENTS === '0') return
+
+	const eventName = process.argv[2]
+	if (!eventName) return
+
+	// Read stdin
+	let stdin: string
+	try {
+		stdin = readFileSync('/dev/stdin', 'utf-8')
+	} catch {
+		return
+	}
+
+	// OOM protection: reject > 1MB before JSON.parse
+	if (stdin.length > 1_000_000) return
+
+	// Validate JSON (don't send garbage to the server)
+	try {
+		JSON.parse(stdin)
+	} catch {
+		return
+	}
+
+	// Discover server
+	if (!existsSync(PORT_FILE)) return
+	const port = parseInt(readFileSync(PORT_FILE, 'utf-8').trim(), 10)
+	if (Number.isNaN(port)) return
+
+	// POST raw stdin to server -- server does all enrichment
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+	try {
+		await fetch(`http://127.0.0.1:${port}/events/${eventName}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: stdin,
+			signal: controller.signal,
+		})
+	} catch (err) {
+		if (DEBUG) console.error(`[obs-hook] ${err}`)
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+main()
+	.catch(() => {})
+	.finally(() => {
+		clearTimeout(selfDestruct)
+		process.exit(0)
+	})

--- a/plugins/observability/hooks/hooks.json
+++ b/plugins/observability/hooks/hooks.json
@@ -1,0 +1,68 @@
+{
+	"description": "Real-time observability -- streams Claude Code lifecycle events to @side-quest/observability server",
+	"hooks": {
+		"SessionStart": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/emit-event.ts\" session-start",
+						"timeout": 5
+					}
+				]
+			}
+		],
+		"PreToolUse": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/emit-event.ts\" pre-tool-use",
+						"timeout": 5,
+						"async": true
+					}
+				]
+			}
+		],
+		"PostToolUse": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/emit-event.ts\" post-tool-use",
+						"timeout": 5,
+						"async": true
+					}
+				]
+			}
+		],
+		"PostToolUseFailure": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/emit-event.ts\" post-tool-use-failure",
+						"timeout": 5,
+						"async": true
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/emit-event.ts\" stop",
+						"timeout": 5
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `observability` plugin -- streams Claude Code lifecycle events (SessionStart, PreToolUse, PostToolUse, PostToolUseFailure, Stop) to `@side-quest/observability` server via fire-and-forget HTTP POSTs
- Single `emit-event.ts` hook handles all 5 events: reads stdin JSON, discovers server via port file at `~/.cache/side-quest-observability/events.port`, POSTs raw payload in 500ms with a 4.5s self-destruct timer
- Bumps marketplace version 1.1.0 -> 1.2.0 (minor, adding a plugin)
- Adds project `CLAUDE.md` with architecture overview and command reference
- Adds `.claude/rules/add-plugin.md` -- step-by-step checklist for future plugin additions

## Test plan

- [ ] `bun run validate` passes
- [ ] `claude plugin validate .` passes from `plugins/observability/`
- [ ] Install via `/plugin install observability@side-quest` and confirm hooks fire (requires `@side-quest/observability` server running)
- [ ] Set `SIDE_QUEST_EVENTS=0` and confirm hooks are silently skipped
- [ ] Kill the observability server and confirm sessions are unaffected (fire-and-forget)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability plugin for real-time event streaming from Claude Code sessions.

* **Documentation**
  * Added comprehensive guide for adding plugins to the marketplace.
  * Updated marketplace documentation with plugin manifest specifications and conventions.

* **Chores**
  * Bumped marketplace version to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->